### PR TITLE
Add CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Leigh MacDonald <leigh.macdonald@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/leighmacdonald/tf2_demostats"
 edition = "2021"
+default-run = "demostats"
 
 [lib]
 name = "tf2_demostats"
@@ -15,6 +16,10 @@ path = "src/lib.rs"
 name = "demostats"
 path = "src/bin/main.rs"
 
+[[bin]]
+name = "cli"
+path = "src/bin/cli.rs"
+
 [dependencies]
 actix-web = "4.9"
 actix-multipart = "0.7.2"
@@ -22,4 +27,6 @@ env_logger = "0.11.3"
 log = "0.4.21"
 tf-demo-parser = "0.5.1"
 fnv = "1.0.7"
+tokio = { version = "1.24.2", features = ["rt", "rt-multi-thread", "macros"] }
 serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.134"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,0 +1,18 @@
+use std::{env, path};
+use tf2_demostats::parser;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("debug"))
+        .format_timestamp(None)
+        .init();
+
+    for arg in env::args().skip(1) {
+        let path = path::Path::new(&arg);
+        let bytes = tokio::fs::read(path).await?;
+        let demo = parser::parse(&bytes).expect("Demo should parse");
+        println!("{}", serde_json::to_string(&demo).unwrap());
+    }
+
+    Ok(())
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,2 +1,15 @@
 pub mod summarizer;
 mod weapon;
+
+use tf_demo_parser::demo::header::Header;
+use tf_demo_parser::demo::parser::player_summary_analyzer::PlayerSummaryState;
+use tf_demo_parser::{Demo, DemoParser};
+
+pub fn parse(buffer: &[u8]) -> tf_demo_parser::Result<(Header, PlayerSummaryState)> {
+    let demo = Demo::new(&buffer);
+    let handler = summarizer::MatchAnalyzer::new();
+    let stream = demo.get_stream();
+    let parser = DemoParser::new_with_analyser(stream, handler);
+
+    parser.parse()
+}

--- a/src/web/handler.rs
+++ b/src/web/handler.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use std::io::Read;
 use tf_demo_parser::demo::header::Header;
 use tf_demo_parser::demo::parser::player_summary_analyzer::PlayerSummaryState;
-use tf_demo_parser::{Demo, DemoParser};
 
 #[derive(Debug, MultipartForm)]
 pub struct UploadForm {
@@ -30,12 +29,8 @@ pub async fn save_files(MultipartForm(mut form): MultipartForm<UploadForm>) -> i
             return HttpResponse::BadRequest().body(e.to_string());
         }
     };
-    let demo = Demo::new(&buffer);
-    let handler = parser::summarizer::MatchAnalyzer::new();
-    let stream = demo.get_stream();
-    let parser = DemoParser::new_with_analyser(stream, handler);
 
-    let (header, state) = match parser.parse() {
+    let (header, state) = match parser::parse(&buffer) {
         Ok((h, s)) => (h, s),
         Err(e) => {
             log::error!("Failed to parse upload {:?}", e);


### PR DESCRIPTION
Extract some of the demo parsing code into a helper, and expose it via a binary

`cargo run --bin cli -- /path/to/my_demo.dem` outputs the final json to stdout. 

The new tokio and serde_json deps aren't actually new -- actix already pulls them in.