### PR TITLE
Return a single JSON object for each demo

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -10,7 +10,8 @@ async fn main() -> std::io::Result<()> {
     for arg in env::args().skip(1) {
         let path = path::Path::new(&arg);
         let bytes = tokio::fs::read(path).await?;
-        let demo = parser::parse(&bytes).expect("Demo should parse");
+        let mut demo = parser::parse(&bytes).expect("Demo should parse");
+        demo.filename = Some(arg);
         println!("{}", serde_json::to_string(&demo).unwrap());
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,15 +2,32 @@ mod game;
 pub mod summarizer;
 mod weapon;
 
+use serde::{Deserialize, Serialize};
 use summarizer::DemoSummary;
 use tf_demo_parser::demo::header::Header;
 use tf_demo_parser::{Demo, DemoParser};
 
-pub fn parse(buffer: &[u8]) -> tf_demo_parser::Result<(Header, DemoSummary)> {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DemoOutput {
+    pub filename: Option<String>,
+
+    #[serde(flatten)]
+    pub header: Header,
+
+    #[serde(flatten)]
+    pub summary: DemoSummary,
+}
+
+pub fn parse(buffer: &[u8]) -> tf_demo_parser::Result<DemoOutput> {
     let demo = Demo::new(&buffer);
     let handler = summarizer::MatchAnalyzer::new();
     let stream = demo.get_stream();
     let parser = DemoParser::new_with_analyser(stream, handler);
 
-    parser.parse()
+    let (header, summary) = parser.parse()?;
+    Ok(DemoOutput {
+        header,
+        summary,
+        filename: None,
+    })
 }


### PR DESCRIPTION
Simpler output structure of {...header_fields, ...demo_data} instead of [{header}, {demo data}]

Also adds the input filename to the output, which is handy for batch processing -- ie I run the CLI over a bunch of demos and want to easily find what demo produced weird results.