### PR TITLE
Switch from log to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ path = "src/bin/cli.rs"
 [dependencies]
 actix-web = "4.9"
 actix-multipart = "0.7.2"
-env_logger = "0.11.3"
-log = "0.4.21"
-tf-demo-parser = "0.5.1"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tf-demo-parser = { version = "0.5.1", features = ["tracing"] }
 fnv = "1.0.7"
 tokio = { version = "1.24.2", features = ["rt", "rt-multi-thread", "macros"] }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,15 +1,26 @@
 use std::{env, path};
 use tf2_demostats::parser;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("debug"))
-        .format_timestamp(None)
+    tracing_subscriber::registry()
+        .with(fmt::layer().without_time().with_target(false))
+        .with(EnvFilter::from_default_env())
         .init();
+
+    let multiple_files = env::args().len() > 2;
 
     for arg in env::args().skip(1) {
         let path = path::Path::new(&arg);
         let bytes = tokio::fs::read(path).await?;
+
+        let _span_guard = if multiple_files {
+            Some(tracing::info_span!("Demo", "File={}", arg).entered())
+        } else {
+            None
+        };
+
         let mut demo = parser::parse(&bytes).expect("Demo should parse");
         demo.filename = Some(arg);
         println!("{}", serde_json::to_string(&demo).unwrap());

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -10,7 +10,8 @@ async fn main() -> std::io::Result<()> {
     for arg in env::args().skip(1) {
         let path = path::Path::new(&arg);
         let bytes = tokio::fs::read(path).await?;
-        let demo = parser::parse(&bytes).expect("Demo should parse");
+        let mut demo = parser::parse(&bytes).expect("Demo should parse");
+        demo.filename = Some(arg);
         println!("{}", serde_json::to_string(&demo).unwrap());
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,15 +2,32 @@ mod game;
 pub mod summarizer;
 mod weapon;
 
+use serde::{Deserialize, Serialize};
 use summarizer::DemoSummary;
 use tf_demo_parser::demo::header::Header;
 use tf_demo_parser::{Demo, DemoParser};
 
-pub fn parse(buffer: &[u8]) -> tf_demo_parser::Result<(Header, DemoSummary)> {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DemoOutput {
+    pub filename: Option<String>,
+
+    #[serde(flatten)]
+    pub header: Header,
+
+    #[serde(flatten)]
+    pub summary: DemoSummary,
+}
+
+pub fn parse(buffer: &[u8]) -> tf_demo_parser::Result<DemoOutput> {
     let demo = Demo::new(&buffer);
     let handler = summarizer::MatchAnalyzer::new();
     let stream = demo.get_stream();
     let parser = DemoParser::new_with_analyser(stream, handler);
 
-    parser.parse()
+    let (header, summary) = parser.parse()?;
+    Ok(DemoOutput {
+        header,
+        summary,
+        filename: None,
+    })
 }

--- a/src/web/handler.rs
+++ b/src/web/handler.rs
@@ -3,6 +3,7 @@ use actix_multipart::form::tempfile::TempFile;
 use actix_multipart::form::MultipartForm;
 use actix_web::{HttpResponse, Responder};
 use std::io::Read;
+use tracing::error;
 
 #[derive(Debug, MultipartForm)]
 pub struct UploadForm {
@@ -16,7 +17,7 @@ pub async fn save_files(MultipartForm(mut form): MultipartForm<UploadForm>) -> i
     match form.file.file.read_to_end(&mut buffer) {
         Ok(f) => f,
         Err(e) => {
-            log::error!("Failed to read upload {:?}", e);
+            error!("Failed to read upload {:?}", e);
             return HttpResponse::BadRequest().body(e.to_string());
         }
     };
@@ -24,7 +25,7 @@ pub async fn save_files(MultipartForm(mut form): MultipartForm<UploadForm>) -> i
     let mut output = match parser::parse(&buffer) {
         Ok(o) => o,
         Err(e) => {
-            log::error!("Failed to parse upload {:?}", e);
+            error!("Failed to parse upload {:?}", e);
             return HttpResponse::BadRequest().body(e.to_string());
         }
     };


### PR DESCRIPTION
Based on top of #3 

Switch to [`tracing`](https://docs.rs/tracing/latest/tracing/) which is more complex than `log` but allows us to see logs from `tf-demo-parser` and other libraries we use. Also added some more context in error logs (ie automatically include tick numbers in all messages, and filenames when CLI is processing multiple files) 

The same `RUST_LOG` env var is used to configure logging.

Performance seems practically the same
```
$ hyperfine --warmup 1 --shell=none --input demos.txt 'xargs ./cli_tracing' 'xargs ./cli_log'     
Benchmark 1: xargs ./cli_tracing
  Time (mean ± σ):      8.642 s ±  0.189 s    [User: 8.502 s, System: 0.131 s]
  Range (min … max):    8.385 s …  8.996 s    10 runs
 
Benchmark 2: xargs ./cli_log
  Time (mean ± σ):      8.633 s ±  0.124 s    [User: 8.498 s, System: 0.126 s]
  Range (min … max):    8.438 s …  8.789 s    10 runs
 
Summary
  xargs ./cli_log ran
    1.00 ± 0.03 times faster than xargs ./cli_tracing
```