### PR TITLE
Basic Airshot stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ path = "src/bin/cli.rs"
 [dependencies]
 actix-web = "4.9"
 actix-multipart = "0.7.2"
-env_logger = "0.11.3"
-log = "0.4.21"
-tf-demo-parser = "0.5.1"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tf-demo-parser = { version = "0.5.1", features = ["tracing"] }
 fnv = "1.0.7"
 tokio = { version = "1.24.2", features = ["rt", "rt-multi-thread", "macros"] }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,15 +1,26 @@
 use std::{env, path};
 use tf2_demostats::parser;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::new().default_filter_or("debug"))
-        .format_timestamp(None)
+    tracing_subscriber::registry()
+        .with(fmt::layer().without_time().with_target(false))
+        .with(EnvFilter::from_default_env())
         .init();
+
+    let multiple_files = env::args().len() > 2;
 
     for arg in env::args().skip(1) {
         let path = path::Path::new(&arg);
         let bytes = tokio::fs::read(path).await?;
+
+        let _span_guard = if multiple_files {
+            Some(tracing::info_span!("Demo", "File={}", arg).entered())
+        } else {
+            None
+        };
+
         let mut demo = parser::parse(&bytes).expect("Demo should parse");
         demo.filename = Some(arg);
         println!("{}", serde_json::to_string(&demo).unwrap());

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -10,7 +10,8 @@ async fn main() -> std::io::Result<()> {
     for arg in env::args().skip(1) {
         let path = path::Path::new(&arg);
         let bytes = tokio::fs::read(path).await?;
-        let demo = parser::parse(&bytes).expect("Demo should parse");
+        let mut demo = parser::parse(&bytes).expect("Demo should parse");
+        demo.filename = Some(arg);
         println!("{}", serde_json::to_string(&demo).unwrap());
     }
 

--- a/src/parser/game.rs
+++ b/src/parser/game.rs
@@ -18,6 +18,11 @@ pub enum RoundState {
     BetweenRounds = 10,
 }
 
+pub const DEATH_FEIGNED: u16 = 0x0020;
+
+pub const ENTITY_ON_GROUND: u16 = 1;
+pub const ENTITY_IN_WATER: u16 = 1 << 9;
+
 #[derive(Deserialize, Serialize, IntoPrimitive, TryFromPrimitive, PartialEq, Debug)]
 #[repr(u16)]
 pub enum WeaponId {
@@ -126,4 +131,48 @@ pub enum WeaponId {
     WeaponPasstimeGun = 102,
     WeaponSniperrifleRevolver = 103,
     WeaponChargedSmg = 104,
+}
+
+#[repr(u8)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TryFromPrimitive)]
+pub enum PlayerAnim {
+    AttackPrimary,
+    AttackSecondary,
+    AttackGrenade,
+    Reload,
+    ReloadLoop,
+    ReloadEnd,
+    Jump,
+    Swim,
+    Die,
+    FlinchChest,
+    FlinchHead,
+    FlinchLeftarm,
+    FlinchRightarm,
+    FlinchLeftleg,
+    FlinchRightleg,
+    Doublejump,
+    Cancel,
+    Spawn,
+    SnapYaw,
+    Custom, // Used to play specific activities
+    CustomGesture,
+    CustomSequence, // Used to play specific sequences
+    CustomGestureSequence,
+    AttackPre,
+    AttackPost,
+    Grenade1Draw,
+    Grenade2Draw,
+    Grenade1Throw,
+    Grenade2Throw,
+    VoiceCommandGesture,
+    DoublejumpCrouch,
+    StunBegin,
+    StunMiddle,
+    StunEnd,
+    PasstimeThrowBegin,
+    PasstimeThrowMiddle,
+    PasstimeThrowEnd,
+    PasstimeThrowCancel,
+    AttackPrimarySuper,
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -19,7 +19,7 @@ pub struct DemoOutput {
 }
 
 pub fn parse(buffer: &[u8]) -> tf_demo_parser::Result<DemoOutput> {
-    let demo = Demo::new(&buffer);
+    let demo = Demo::new(buffer);
     let handler = summarizer::MatchAnalyzer::new();
     let stream = demo.get_stream();
     let parser = DemoParser::new_with_analyser(stream, handler);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,15 +2,32 @@ mod game;
 pub mod summarizer;
 mod weapon;
 
+use serde::{Deserialize, Serialize};
 use summarizer::DemoSummary;
 use tf_demo_parser::demo::header::Header;
 use tf_demo_parser::{Demo, DemoParser};
 
-pub fn parse(buffer: &[u8]) -> tf_demo_parser::Result<(Header, DemoSummary)> {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DemoOutput {
+    pub filename: Option<String>,
+
+    #[serde(flatten)]
+    pub header: Header,
+
+    #[serde(flatten)]
+    pub summary: DemoSummary,
+}
+
+pub fn parse(buffer: &[u8]) -> tf_demo_parser::Result<DemoOutput> {
     let demo = Demo::new(&buffer);
     let handler = summarizer::MatchAnalyzer::new();
     let stream = demo.get_stream();
     let parser = DemoParser::new_with_analyser(stream, handler);
 
-    parser.parse()
+    let (header, summary) = parser.parse()?;
+    Ok(DemoOutput {
+        header,
+        summary,
+        filename: None,
+    })
 }

--- a/src/web/handler.rs
+++ b/src/web/handler.rs
@@ -3,6 +3,7 @@ use actix_multipart::form::tempfile::TempFile;
 use actix_multipart::form::MultipartForm;
 use actix_web::{HttpResponse, Responder};
 use std::io::Read;
+use tracing::error;
 
 #[derive(Debug, MultipartForm)]
 pub struct UploadForm {
@@ -16,7 +17,7 @@ pub async fn save_files(MultipartForm(mut form): MultipartForm<UploadForm>) -> i
     match form.file.file.read_to_end(&mut buffer) {
         Ok(f) => f,
         Err(e) => {
-            log::error!("Failed to read upload {:?}", e);
+            error!("Failed to read upload {:?}", e);
             return HttpResponse::BadRequest().body(e.to_string());
         }
     };
@@ -24,7 +25,7 @@ pub async fn save_files(MultipartForm(mut form): MultipartForm<UploadForm>) -> i
     let mut output = match parser::parse(&buffer) {
         Ok(o) => o,
         Err(e) => {
-            log::error!("Failed to parse upload {:?}", e);
+            error!("Failed to parse upload {:?}", e);
             return HttpResponse::BadRequest().body(e.to_string());
         }
     };


### PR DESCRIPTION
Based on top of #4 

Airshot tracking works :) I manually watched the logged ticks for a
few demos and the current heuristic (in the air for at least 16 ticks
before being killed) seems reasonable.

Notably no weapon filtering yet, and for explosives: no direct vs
splash damage filtering.

Supstats2 defines airshots based off the victim's height off the
ground:
https://github.com/F2/F2s-sourcemod-plugins/blob/f893dd7e49c8f09c70a86c0024c31ee303b3d1b8/supstats2/supstats2.sp#L1135

But that would be really hard for us to implement... I don't think
either heuristic is perfect but we can iterate on it, perhaps
incorporating player velocity and animation state.