### PR TITLE
Switch schema parsing to load VDF from tf2's items_game.txt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ serde_json = "1.0.134"
 num_enum = "0.7.3"
 bit-set = "0.8.0"
 enumset = "1.1.5"
+awc = { version = "3.5.1", features = ["rustls"] }
+keyvalues-serde = "0.2.2"
+merge = "0.1.0"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,21 +1,17 @@
 use std::{env, path};
-use tf2_demostats::{parser, schema};
+use tf2_demostats::{parser, schema, Result};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-#[tokio::main]
-async fn main() -> std::io::Result<()> {
+#[actix_web::main]
+async fn main() -> Result<()> {
     tracing_subscriber::registry()
         .with(fmt::layer().without_time().with_target(false))
         .with(EnvFilter::from_default_env())
         .init();
 
-    let multiple_files = env::args().len() > 2;
+    let schema = schema::fetch().await?;
 
-    let schema_string = std::env::var("TF2_SCHEMA_PATH")
-        .expect("TF2_SCHEMA_PATH must be set")
-        .to_string();
-    let schema_path = path::Path::new(&schema_string);
-    let schema = schema::parse(schema_path)?;
+    let multiple_files = env::args().len() > 2;
 
     for arg in env::args().skip(1) {
         let path = path::Path::new(&arg);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,8 +1,8 @@
 use actix_multipart::form::tempfile::TempFileConfig;
 use actix_multipart::form::MultipartFormConfig;
 use actix_web::{error, middleware, web, App, Error, HttpRequest, HttpResponse, HttpServer};
-use std::{env, fs, path};
-use tf2_demostats::{schema, web::handler};
+use std::{env, fs};
+use tf2_demostats::{schema, web::handler, Result};
 use tracing::info;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
@@ -12,7 +12,7 @@ fn handle_multipart_error(err: actix_multipart::MultipartError, _req: &HttpReque
 }
 
 #[actix_web::main]
-async fn main() -> std::io::Result<()> {
+async fn main() -> Result<()> {
     let host = env::var("DEMO_HOST").unwrap_or_else(|_e| String::from("0.0.0.0"));
     let port = env::var("DEMO_PORT")
         .unwrap_or_else(|_e| String::from("8811"))
@@ -25,18 +25,11 @@ async fn main() -> std::io::Result<()> {
         .with(EnvFilter::from_default_env())
         .init();
 
-    let schema_string = std::env::var("DEMO_TF2_SCHEMA_PATH")
-        .or(std::env::var("TF2_SCHEMA_PATH"))
-        .expect("DEMO_TF2_SCHEMA_PATH must be set")
-        .to_string();
-    let schema_path = path::Path::new(&schema_string);
-    let schema = schema::parse(schema_path)?;
-    info!("Loaded TF2 schema from {}", &schema_string);
-
+    let schema = schema::fetch().await?;
     let schema_data = web::Data::new(schema);
 
     info!("Starting HTTP Service on {}:{}", &host, &port);
-    HttpServer::new(move || {
+    let _ = HttpServer::new(move || {
         App::new()
             .wrap(middleware::Compress::default())
             .wrap(middleware::Logger::default())
@@ -60,5 +53,7 @@ async fn main() -> std::io::Result<()> {
         bind((host, port))?.
         //workers(4). // TODO Add env var
         run().
-        await
+        await;
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,6 @@ extern crate core;
 pub mod parser;
 pub mod schema;
 pub mod web;
+
+pub type Result<T> = core::result::Result<T, Error>;
+pub type Error = Box<dyn std::error::Error>;

--- a/src/parser/summarizer.rs
+++ b/src/parser/summarizer.rs
@@ -6,7 +6,7 @@ use crate::{
         },
         weapon::Weapon,
     },
-    schema::{Item, Schema},
+    schema::{Attribute, Item, Schema},
 };
 use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
@@ -444,9 +444,11 @@ impl PlayerSummary {
     fn handle_charged(&mut self, _medigun: &WeaponState, medigun_item: &Item) {
         let charge_type = medigun_item
             .attributes
-            .iter()
-            .find(|a| a.class == "set_charge_type")
-            .map(|a| a.value)
+            .get("set_charge_type")
+            .and_then(|x| match x {
+                Attribute::Float(float) => Some(float.value),
+                _ => None,
+            })
             .unwrap_or(0.0);
 
         match charge_type {
@@ -1146,7 +1148,7 @@ impl<'a> MatchAnalyzer<'a> {
                     if let Some(uid) = self.weapon_owners.get(&handle) {
                         if let Some(player) = self.state.player_summaries.get_mut(uid) {
                             if let Some(medigun) = self.weapon_handles.get(&handle) {
-                                if let Some(item) = self.schema.get(&medigun.id) {
+                                if let Some(item) = self.schema.items.get(&medigun.id) {
                                     player.handle_charged(medigun, item);
                                 } else {
                                     error!(


### PR DESCRIPTION
Actually we do need the full VDF schema, not the JSON one I previously added support for :\ The VDF version includes more weapon attributes we need to look at, and it has the lognames for some weapons. 

This is the file `scripts/items/items_game.txt` file in a tf2_directory.

upside: This is also available via exactly 2 HTTP requests instead of having to fetch multiple pages.

downside: Need to pull in a vdf parser (and had to send a PR for them to expose a "raw" API since the schema has some weird characters in some strings...). Had to implement "prefab" logic for generating full item names.

Fortunately running through the full schema and applying prefabs is very fast, so I just do it eagerly up front (we could conceivably do it lazily only for items we actually encounter in a demo but the complexity doesn't seem worth it).

Fixes #11 