### PR TITLE
Per-weapon KDA and damage stat tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,21 @@ path = "src/bin/cli.rs"
 [dependencies]
 actix-web = "4.9"
 actix-multipart = "0.7.2"
-tracing = { version = "0.1.41", features = ["release_max_level_warn"] }
+tracing = { version = "0.1.41", features = ["release_max_level_info"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-tf-demo-parser = { version = "0.5.1", features = ["trace"] }
-fnv = "1.0.7"
+tf-demo-parser = { git = "https://github.com/demostf/parser.git", rev = "e7451375c250d49802948c9d6d6a535a9575e910" }
 tokio = { version = "1.24.2", features = ["rt", "rt-multi-thread", "macros"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.134"
 num_enum = "0.7.3"
-bit-set = "0.8.0"
 enumset = "1.1.5"
 awc = { version = "3.5.1", features = ["rustls"] }
 keyvalues-serde = "0.2.2"
 merge = "0.1.0"
+nalgebra = { version = "0.33.2", features = ["alga"] }
+parry3d = "0.18.0"
+alga = "0.9"
+rapier3d = "0.23.0"
+lazy_static = "1.5.0"
+optfield = "0.4.0"
+ustr = "1.1.0"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -5,7 +5,12 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 #[actix_web::main]
 async fn main() -> Result<()> {
     tracing_subscriber::registry()
-        .with(fmt::layer().without_time().with_target(false))
+        .with(
+            fmt::layer()
+                .without_time()
+                .with_target(false)
+                .with_writer(std::io::stderr),
+        )
         .with(EnvFilter::from_default_env())
         .init();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use tf_demo_parser::demo::vector::Vector;
+
 extern crate core;
 
 pub mod parser;
@@ -6,3 +8,10 @@ pub mod web;
 
 pub type Result<T> = core::result::Result<T, Error>;
 pub type Error = Box<dyn std::error::Error>;
+
+type Vec3 = nalgebra::Point<f32, 3>;
+type Vec2 = nalgebra::Point2<f32>;
+
+fn convert_vec(vec: Vector) -> Vec3 {
+    Vec3::new(vec.x, vec.y, vec.z)
+}

--- a/src/parser/entity/mod.rs
+++ b/src/parser/entity/mod.rs
@@ -1,0 +1,138 @@
+use crate::{parser::summarizer::MatchAnalyzerView, Vec3};
+use nalgebra::vector;
+use optfield::optfield;
+use parry3d::shape::{Cuboid, SharedShape};
+use std::any::Any;
+use tf_demo_parser::{demo::message::packetentities::PacketEntity, ParserState};
+
+pub mod sentry;
+pub use sentry::*;
+
+pub mod projectile;
+pub use projectile::*;
+
+pub mod weapon;
+pub use weapon::*;
+
+pub mod player;
+pub use player::*;
+
+pub mod shield;
+pub use shield::*;
+
+#[derive(Debug, PartialEq)]
+pub enum EntityClass {
+    Projectile,
+    Sentry,
+    Weapon,
+    Shield,
+    Player,
+    PlayerResource,
+    Unknown,
+}
+
+// TODO: Use a real ECS like bevy_ecs? Or at least switch back to an enum with variants.
+
+pub trait Entity: std::fmt::Debug {
+    fn new(packet: &PacketEntity, parser_state: &ParserState, game: &mut MatchAnalyzerView) -> Self
+    where
+        Self: Sized;
+
+    fn parse_preserve(
+        &self,
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> Box<dyn Any>;
+
+    fn apply_preserve(&mut self, patch: Box<dyn Any>);
+
+    // Entities are stored as Box<dyn T> for polymorphism, but that means
+    // the consuming methods delete()/leave() cannot be invoked until
+    // https://github.com/rust-lang/rust/issues/48055 is stabilizied.
+    //
+    // This Boxed trait is a workaround from
+    // https://users.rust-lang.org/t/call-consuming-method-for-dyn-trait-object/69596/7
+    fn delete(self: Box<Self>, _game: &mut MatchAnalyzerView) {}
+    fn leave(self: Box<Self>, game: &mut MatchAnalyzerView) {
+        self.delete(game);
+    }
+
+    // Optional collision
+    fn shape(&self) -> Option<SharedShape> {
+        None
+    }
+    fn origin(&self) -> Option<Vec3> {
+        None
+    }
+
+    fn owner(&self) -> Option<u32> {
+        None
+    }
+
+    fn handle(&self) -> Option<u32> {
+        None
+    }
+
+    fn class(&self) -> EntityClass;
+
+    // Hacky downcasts
+    fn player(&self) -> Option<&Player> {
+        None
+    }
+    fn weapon(&self) -> Option<&Weapon> {
+        None
+    }
+    fn projectile(&self) -> Option<&Projectile> {
+        None
+    }
+    fn sentry(&self) -> Option<&Sentry> {
+        None
+    }
+    fn shield(&self) -> Option<&Shield> {
+        None
+    }
+}
+
+#[optfield(UnknownPatch, merge_fn, attrs)]
+#[derive(Debug, Default)]
+pub struct Unknown {}
+
+impl Entity for Unknown {
+    fn new(
+        _packet: &PacketEntity,
+        _parser_state: &ParserState,
+        _game: &mut MatchAnalyzerView,
+    ) -> Self
+    where
+        Self: Sized,
+    {
+        Unknown {}
+    }
+
+    fn parse_preserve(
+        &self,
+        _packet: &PacketEntity,
+        _parser_state: &ParserState,
+        _game: &mut MatchAnalyzerView,
+    ) -> Box<dyn Any> {
+        Box::new(UnknownPatch::default())
+    }
+
+    fn apply_preserve(&mut self, patch: Box<dyn Any>) {
+        let patch = patch.downcast::<UnknownPatch>().unwrap();
+        self.merge_opt(*patch);
+    }
+
+    fn class(&self) -> EntityClass {
+        EntityClass::Unknown
+    }
+}
+
+lazy_static::lazy_static! {
+    // TODO: real valuess, switch by sentry level
+    static ref SENTRY_BOX: SharedShape = SharedShape::new(Cuboid::new(vector![49.0, 49.0, 83.0]));
+
+    // TODO: real valuess, switch by projectile type
+    static ref PROJECTILE_BOX: SharedShape = SharedShape::new(Cuboid::new(vector![10.0, 10.0, 10.0]));
+}

--- a/src/parser/entity/player.rs
+++ b/src/parser/entity/player.rs
@@ -1,0 +1,408 @@
+use crate::{
+    parser::{
+        entity::{Entity, EntityClass},
+        game::{update_condition, Flags, PlayerCondition, INVALID_HANDLE},
+        props::*,
+        summarizer::MatchAnalyzerView,
+    },
+    Vec2, Vec3,
+};
+use enumset::EnumSet;
+use std::any::Any;
+use tf_demo_parser::{
+    demo::{
+        data::DemoTick,
+        message::packetentities::PacketEntity,
+        parser::analyser::{Class, Team, UserId},
+        sendprop::SendPropValue,
+        vector::VectorXY,
+    },
+    ParserState,
+};
+use tracing::{error, trace};
+
+//#[optfield::optfield(PlayerPatch, merge_fn, attrs)]
+#[derive(Debug, PartialEq, Default)]
+pub struct Player {
+    pub class: Class,
+    pub team: Team,
+    pub tick_start: Option<DemoTick>,
+    pub tick_end: Option<DemoTick>,
+    pub user_id: UserId,
+
+    pub health: u32,
+
+    // medic
+    pub charge: f32,
+    pub kritzed: bool,
+
+    pub points: Option<u32>,
+    pub connection_count: u32,
+    pub bonus_points: Option<u32>,
+
+    pub scoreboard_kills: u32,
+    pub scoreboard_assists: u32,
+    pub scoreboard_deaths: u32,
+    pub scoreboard_healing: u32,
+
+    pub captures: u32,
+    pub captures_blocked: u32,
+
+    pub scoreboard_damage: u32,
+    pub on_ground: bool,
+    pub in_water: bool,
+    pub started_flying: DemoTick,
+
+    pub sim_time: u32,
+    pub origin: Vec3,
+    pub eye: Vec2,
+    pub condition: EnumSet<PlayerCondition>,
+    pub condition_source: u32,
+
+    pub last_active_weapon_handle: u32,
+    pub active_weapon_handle: u32,
+    pub weapon_handles: Box<[u32; 7]>,
+    pub cosmetic_handles: Box<[u32; 8]>,
+
+    pub handle: u32,
+}
+
+#[derive(Default)]
+struct PlayerPatch {
+    scoreboard_kills: Option<u32>,
+    scoreboard_assists: Option<u32>,
+    scoreboard_deaths: Option<u32>,
+    flags: Option<EnumSet<Flags>>,
+    class: Option<Class>,
+    team: Option<Team>,
+    health: Option<u32>,
+    sim_time: Option<u32>,
+    origin_xy: Option<VectorXY>,
+    origin_z: Option<f32>,
+    eye_x: Option<f32>,
+    eye_y: Option<f32>,
+    handle: Option<u32>,
+    kritzed: Option<bool>,
+    active_weapon_handle: Option<u32>,
+    condition_source: Option<u32>,
+    condition_bits: [Option<u32>; 4],
+    weapon_handles: [Option<u32>; 7],
+
+    num_cosmetics: Option<u32>,
+    cosmetics: [Option<u32>; 8],
+}
+
+impl Player {
+    fn parse(packet: &PacketEntity, parser_state: &ParserState, patch: &mut PlayerPatch) {
+        for prop in packet.props(parser_state) {
+            match (prop.identifier, &prop.value) {
+                (KILLS, &SendPropValue::Integer(val)) => {
+                    patch.scoreboard_kills = Some(val as u32);
+                }
+                (KILL_ASSISTS, &SendPropValue::Integer(val)) => {
+                    // PoV demos include multiple different copies of
+                    // this field -- maybe per round stats? We want
+                    // the larger one.
+                    // TODO
+                    patch.scoreboard_assists = Some(val as u32);
+                }
+                (DEATHS, &SendPropValue::Integer(val)) => {
+                    patch.scoreboard_deaths = Some(val as u32);
+                }
+                (FLAGS, &SendPropValue::Integer(val)) => {
+                    patch.flags = Some(EnumSet::<Flags>::try_from_repr(val as u32).unwrap_or_else(
+                        || {
+                            error!("Unknown player flags: {}", val);
+                            EnumSet::<Flags>::new()
+                        },
+                    ));
+                }
+                (CLASS, &SendPropValue::Integer(val)) => {
+                    let Ok(class) = Class::try_from(val as u8) else {
+                        error!("Unknown classid {val}");
+                        continue;
+                    };
+                    patch.class = Some(class);
+                }
+                (TEAM, &SendPropValue::Integer(val)) => {
+                    let Ok(team) = Team::try_from(val as u8) else {
+                        error!("Unknown team id {val}");
+                        continue;
+                    };
+                    patch.team = Some(team);
+                }
+                (HEALTH, &SendPropValue::Integer(val)) => {
+                    patch.health = Some(val as u32);
+                }
+                (SIM_TIME, &SendPropValue::Integer(val)) => {
+                    patch.sim_time = Some(val as u32);
+                }
+
+                (ORIGIN_XY, &SendPropValue::VectorXY(vec)) => {
+                    patch.origin_xy = Some(vec);
+                }
+                (ORIGIN_Z, &SendPropValue::Float(z)) => patch.origin_z = Some(z),
+                (EYE_X, &SendPropValue::Float(x)) => patch.eye_x = Some(x),
+                (EYE_Y, &SendPropValue::Float(y)) => patch.eye_y = Some(y),
+
+                (HANDLE, &SendPropValue::Integer(h)) => {
+                    patch.handle = Some(h as u32);
+                }
+                (COND_SOURCE, &SendPropValue::Integer(x)) => {
+                    patch.condition_source = Some(x as u32)
+                }
+
+                (COND_0, &SendPropValue::Integer(x)) => patch.condition_bits[0] = Some(x as u32),
+                (COND_1, &SendPropValue::Integer(x)) => patch.condition_bits[1] = Some(x as u32),
+                (COND_2, &SendPropValue::Integer(x)) => patch.condition_bits[2] = Some(x as u32),
+                (COND_3, &SendPropValue::Integer(x)) => patch.condition_bits[3] = Some(x as u32),
+
+                (COND_BITS, &SendPropValue::Integer(x)) => {
+                    if x == 0 || x == 2048 {
+                        patch.kritzed = Some(x == 2048);
+                    } else {
+                        error!("Unknown _condition_bits: {x}");
+                    }
+                }
+
+                (ACTIVE_WEAPON_HANDLE, &SendPropValue::Integer(x)) => {
+                    patch.active_weapon_handle = Some(x as u32);
+                }
+
+                (WEP_0, &SendPropValue::Integer(x)) => {
+                    patch.weapon_handles[0] = Some(x as u32);
+                }
+                (WEP_1, &SendPropValue::Integer(x)) => {
+                    patch.weapon_handles[1] = Some(x as u32);
+                }
+                (WEP_2, &SendPropValue::Integer(x)) => {
+                    patch.weapon_handles[2] = Some(x as u32);
+                }
+                (WEP_3, &SendPropValue::Integer(x)) => {
+                    patch.weapon_handles[3] = Some(x as u32);
+                }
+                (WEP_4, &SendPropValue::Integer(x)) => {
+                    patch.weapon_handles[4] = Some(x as u32);
+                }
+                (WEP_5, &SendPropValue::Integer(x)) => {
+                    patch.weapon_handles[5] = Some(x as u32);
+                }
+                (WEP_6, &SendPropValue::Integer(x)) => {
+                    patch.weapon_handles[6] = Some(x as u32);
+                }
+
+                (NUM_COSMETICS, &SendPropValue::Integer(n)) => patch.num_cosmetics = Some(n as u32),
+                (COSMETIC_0, &SendPropValue::Integer(x)) => patch.cosmetics[0] = Some(x as u32),
+                (COSMETIC_1, &SendPropValue::Integer(x)) => patch.cosmetics[1] = Some(x as u32),
+                (COSMETIC_2, &SendPropValue::Integer(x)) => patch.cosmetics[2] = Some(x as u32),
+                (COSMETIC_3, &SendPropValue::Integer(x)) => patch.cosmetics[3] = Some(x as u32),
+                (COSMETIC_4, &SendPropValue::Integer(x)) => patch.cosmetics[4] = Some(x as u32),
+                (COSMETIC_5, &SendPropValue::Integer(x)) => patch.cosmetics[5] = Some(x as u32),
+                (COSMETIC_6, &SendPropValue::Integer(x)) => patch.cosmetics[6] = Some(x as u32),
+                (COSMETIC_7, &SendPropValue::Integer(x)) => patch.cosmetics[7] = Some(x as u32),
+
+                _ => {}
+            }
+            trace!("player wep {:?} {prop:?}", packet.entity_index);
+        }
+    }
+
+    fn apply_patch(&mut self, patch: &PlayerPatch) {
+        self.handle = patch.handle.unwrap_or(self.handle);
+        self.health = patch.health.unwrap_or(self.health);
+        self.condition_source = patch.condition_source.unwrap_or(self.condition_source);
+        self.kritzed = patch.kritzed.unwrap_or(self.kritzed);
+        self.class = patch.class.unwrap_or(self.class);
+        self.team = patch.team.unwrap_or(self.team);
+
+        if let Some(xy) = patch.origin_xy {
+            self.origin.x = xy.x;
+            self.origin.y = xy.y;
+        }
+        if let Some(z) = patch.origin_z {
+            self.origin.z = z;
+        }
+
+        if let Some(x) = patch.eye_x {
+            self.eye.x = x;
+        }
+        if let Some(y) = patch.eye_y {
+            self.eye.y = y;
+        }
+
+        if let Some(bits) = patch.condition_bits[0] {
+            update_condition::<0>(&mut self.condition, bits);
+        }
+        if let Some(bits) = patch.condition_bits[1] {
+            update_condition::<32>(&mut self.condition, bits);
+        }
+        if let Some(bits) = patch.condition_bits[2] {
+            update_condition::<64>(&mut self.condition, bits);
+        }
+        if let Some(bits) = patch.condition_bits[3] {
+            update_condition::<96>(&mut self.condition, bits);
+        }
+
+        if let Some(aw) = patch.active_weapon_handle {
+            self.active_weapon_handle = aw;
+            if aw != INVALID_HANDLE {
+                self.last_active_weapon_handle = aw;
+            }
+        }
+
+        for (i, &w) in patch.weapon_handles.iter().enumerate() {
+            if let Some(w) = w {
+                self.weapon_handles[i] = w;
+            }
+        }
+
+        for (i, &c) in patch.cosmetics.iter().enumerate() {
+            if let Some(c) = c {
+                self.cosmetic_handles[i] = c;
+            }
+        }
+    }
+}
+
+impl Entity for Player {
+    fn new(
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> Self {
+        let mut patch = PlayerPatch::default();
+        Player::parse(packet, parser_state, &mut patch);
+
+        let mut s = Self::default();
+
+        if let Some(&user_id) = game.user_entities.get(&packet.entity_index) {
+            s.user_id = user_id;
+
+            if let Some(summary) = game.player_summaries.get_mut(&user_id) {
+                summary.class = patch.class.unwrap_or(summary.class);
+                summary.health = patch.health.unwrap_or(summary.health);
+
+                for &w in patch.weapon_handles.iter() {
+                    if let Some(w) = w {
+                        game.weapon_owners.insert(w, user_id);
+                    }
+                }
+
+                for &c in patch.cosmetics.iter() {
+                    if let Some(c) = c {
+                        game.cosmetic_owners.insert(c, user_id);
+                    }
+                }
+            } else {
+                error!("No summary for new player user id: {}", s.user_id);
+            }
+        } else {
+            error!("No user id ready for new user! {packet:?}")
+        }
+
+        s.apply_patch(&patch);
+
+        s.tick_start = Some(game.tick);
+
+        s
+    }
+
+    fn parse_preserve(
+        &self,
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> Box<dyn Any> {
+        let user_id = self.user_id;
+
+        let mut patch = Box::new(PlayerPatch::default());
+        Player::parse(packet, parser_state, &mut patch);
+
+        let Some(summary) = game.player_summaries.get_mut(&user_id) else {
+            error!("Unknown player user id: {}", user_id);
+            return patch;
+        };
+
+        if let Some(kills) = patch.scoreboard_kills {
+            summary.scoreboard_kills = Some(kills);
+        }
+
+        // PoV demos include multiple different copies of this field -- maybe per round stats? We
+        // want the larger one.*val as u32));
+        if let Some(assists) = patch.scoreboard_assists {
+            summary.scoreboard_assists = Some(summary.scoreboard_assists.unwrap_or(0).max(assists));
+        }
+
+        // PoV demos include multiple different copies of this field -- maybe per round stats? We
+        // want the larger one.*val as u32));
+        if let Some(deaths) = patch.scoreboard_deaths {
+            summary.scoreboard_deaths = Some(deaths);
+        }
+
+        if let Some(flags) = patch.flags {
+            let was_in_air = summary.in_air();
+            summary.on_ground = flags.contains(Flags::OnGround);
+            summary.in_water = flags.contains(Flags::InWater);
+            let now_in_air = summary.in_air();
+            if !was_in_air && now_in_air {
+                summary.started_flying = game.tick;
+            }
+        }
+
+        if let Some(xy) = patch.origin_xy {
+            summary.origin.x = xy.x;
+            summary.origin.y = xy.y;
+        }
+        if let Some(z) = patch.origin_z {
+            summary.origin.z = z;
+        }
+
+        if let Some(aw) = patch.active_weapon_handle {
+            game.weapon_owners.insert(aw, user_id);
+        }
+
+        for &w in patch.weapon_handles.iter() {
+            if let Some(w) = w {
+                game.weapon_owners.insert(w, user_id);
+            }
+        }
+
+        for &c in patch.cosmetics.iter() {
+            if let Some(c) = c {
+                game.cosmetic_owners.insert(c, user_id);
+            }
+        }
+
+        summary.class = patch.class.unwrap_or(summary.class);
+        summary.health = patch.health.unwrap_or(summary.health);
+
+        patch
+    }
+
+    fn apply_preserve(&mut self, patch: Box<dyn Any>) {
+        let patch = patch.downcast::<PlayerPatch>().unwrap();
+        self.apply_patch(&patch);
+    }
+
+    fn delete(self: Box<Self>, game: &mut MatchAnalyzerView) {
+        let user_id = self.user_id;
+        let Some(summary) = game.player_summaries.get_mut(&user_id) else {
+            error!("Unknown player user id: {}", user_id);
+            return;
+        };
+        trace!("Player left {self:?}");
+        summary.tick_end = Some(game.tick);
+    }
+
+    fn handle(&self) -> Option<u32> {
+        Some(self.handle)
+    }
+
+    fn class(&self) -> EntityClass {
+        EntityClass::Player
+    }
+
+    fn player(&self) -> Option<&Player> {
+        Some(self)
+    }
+}

--- a/src/parser/entity/projectile.rs
+++ b/src/parser/entity/projectile.rs
@@ -1,0 +1,491 @@
+use crate::{
+    convert_vec,
+    parser::{
+        entity::{Entity, EntityClass, PROJECTILE_BOX},
+        game::{Effects, GrenadeType, INVALID_HANDLE},
+        props::*,
+        summarizer::{Explosion, MatchAnalyzerView},
+        weapon::projectile_explosion_radius,
+    },
+    schema::{Attribute, StringAttribute},
+    Vec3,
+};
+use enumset::EnumSet;
+use nalgebra::Vector3;
+use parry3d::shape::SharedShape;
+use rapier3d::prelude::{Aabb, Ball, BoundingVolume, Cuboid, QueryFilter};
+use std::any::Any;
+use tf_demo_parser::{
+    demo::{
+        message::packetentities::PacketEntity, packet::datatable::ClassId, parser::analyser::Team,
+        sendprop::SendPropValue,
+    },
+    ParserState,
+};
+use tracing::error;
+
+#[optfield::optfield(ProjectilePatch, merge_fn, attrs)]
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Projectile {
+    pub original_launcher_handle: u32,
+    pub launcher_schema_id: Option<u32>,
+    pub is_sentry: bool,
+    pub origin: Vec3,
+    pub velocity: Vec3, // computed
+    pub original_owner: u32,
+    pub owner: u32,
+    pub is_reflected: bool,
+    pub original_team: Team,
+    pub team: Team,
+    pub class_name: String,
+    pub grenade_type: Option<GrenadeType>,
+    pub model_id: Option<u32>,
+    pub kind: ProjectileType,
+    pub effects: EnumSet<Effects>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
+pub enum ProjectileType {
+    EnergyRing, // Pomson, Bison
+    HealingBolt,
+    Rocket,
+    Sandman,
+    ShortCircuit,
+    SentryRocket,
+    MadMilk,
+    DragonsFuryFire,
+    RescueRanger,
+    HuntsmanArrow,
+    Flare,
+    DetonatorFlare,
+    ManmelterFlare,
+    ScorchShotFlare,
+    Cleaver,
+    Jarate,
+    GasPasser,
+    QuickieBomb,
+    ScottishResistance,
+    StickyBomb,
+    StickyBombJumper,
+    IronBomber,
+    Pipe,
+    LochNLoad,
+    LooseCannon,
+    WrapAssassin,
+    CowMangler,
+    #[default]
+    Unknown,
+}
+
+pub fn is_sticky(kind: ProjectileType) -> bool {
+    matches!(
+        kind,
+        ProjectileType::StickyBomb
+            | ProjectileType::StickyBombJumper
+            | ProjectileType::ScottishResistance
+            | ProjectileType::QuickieBomb
+    )
+}
+
+pub fn is_arrow(kind: ProjectileType) -> bool {
+    matches!(
+        kind,
+        ProjectileType::HealingBolt | ProjectileType::HuntsmanArrow | ProjectileType::RescueRanger
+    )
+}
+
+pub fn can_hurt_without_exploding(kind: ProjectileType) -> bool {
+    matches!(
+        kind,
+        ProjectileType::HuntsmanArrow
+            | ProjectileType::ShortCircuit
+            | ProjectileType::EnergyRing
+            | ProjectileType::ScorchShotFlare
+    )
+}
+
+impl Projectile {
+    fn parse(
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &MatchAnalyzerView,
+        patch: &mut ProjectilePatch,
+    ) {
+        let class_name = parser_state
+            .server_classes
+            .get(<ClassId as Into<usize>>::into(packet.server_class))
+            .map(|s| s.name.to_string())
+            .unwrap_or("UNKNOWN_PROJECTILE".to_string());
+
+        for prop in packet.props(parser_state) {
+            match (prop.identifier, &prop.value) {
+                (ORIGIN | ROCKET_ORIGIN | GRENADE_ORIGIN, &SendPropValue::Vector(o)) => {
+                    patch.origin = Some(convert_vec(o));
+                }
+                (ROCKET_DEFLECTED | GRENADE_DEFLECTED, &SendPropValue::Integer(b)) => {
+                    patch.is_reflected = Some(b > 0)
+                }
+                (OWNER | DEFLECT_OWNER, &SendPropValue::Integer(h)) => {
+                    let h = h as u32;
+                    if h != INVALID_HANDLE {
+                        patch.owner = Some(h);
+                    }
+                }
+
+                (ORIGINAL_LAUNCHER, &SendPropValue::Integer(h)) => {
+                    let launcher = h as u32;
+                    if launcher != INVALID_HANDLE {
+                        patch.original_launcher_handle = Some(launcher);
+                    }
+
+                    // set owner based on the launcher weapon, needed for some projectiles.
+                    if patch.owner.is_none() {
+                        let handle = game
+                            .weapon_owners
+                            .get(&launcher)
+                            .and_then(|uid| game.player_summaries.get(uid))
+                            .and_then(|p| game.get_player(&p.entity_id))
+                            .and_then(|p| p.handle());
+
+                        patch.owner = handle;
+                    }
+                }
+
+                (TEAM, &SendPropValue::Integer(t)) => {
+                    if let Ok(team_val) = Team::try_from(t as u8) {
+                        patch.team = Some(team_val);
+                    } else {
+                        error!("Invalid team value {t}");
+                    }
+                }
+
+                (PIPE_TYPE, &SendPropValue::Integer(t)) => {
+                    if class_name != "CTFGrenadePipebombProjectile" {
+                        // Jars have this field set for some reason -- but it doesn't differentiate
+                        // anything.
+                        continue;
+                    }
+
+                    let Ok(grenade_type) = GrenadeType::try_from(t as u16) else {
+                        error!("Unknown grenade type {t} when parsing {packet:?}");
+                        continue;
+                    };
+                    patch.grenade_type = Some(grenade_type);
+                }
+                (MODEL, &SendPropValue::Integer(t)) => {
+                    patch.model_id = Some(t as u32);
+                }
+
+                (EFFECTS, &SendPropValue::Integer(f)) => {
+                    patch.effects = Some(
+                        EnumSet::<Effects>::try_from_repr(f as u16).unwrap_or_else(|| {
+                            error!("Unknown entity effects on projectile: {}", f);
+                            EnumSet::<_>::new()
+                        }),
+                    );
+                }
+
+                (INITIAL_SPEED, _) => {}
+                (ROCKET_ROTATION | GRENADE_ROTATION, _) => {}
+
+                _ => {}
+            }
+        }
+    }
+
+    pub fn check_hit(&self, volume: &Aabb) -> bool {
+        if is_arrow(self.kind)
+            || self.kind == ProjectileType::ShortCircuit
+            || self.kind == ProjectileType::EnergyRing
+        {
+            let hitbox = if is_arrow(self.kind) {
+                Cuboid::new(Vector3::new(2.0, 2.0, 2.0))
+            } else {
+                Cuboid::new(Vector3::new(100.0, 100.0, 100.0))
+            };
+
+            // TODO: do a proper ShapeCast if necessary...
+            return hitbox.aabb(&self.origin.into()).intersects(volume)
+                || hitbox
+                    .aabb(&(self.origin + self.velocity.coords / 2.0).into())
+                    .intersects(volume)
+                || hitbox
+                    .aabb(&(self.origin + self.velocity.coords).into())
+                    .intersects(volume);
+        }
+
+        let explosion_ball = Ball::new(projectile_explosion_radius(&self.class_name));
+
+        explosion_ball.aabb(&self.origin.into()).intersects(volume)
+    }
+}
+
+impl Entity for Projectile {
+    fn new(
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> Self {
+        let class_name = parser_state
+            .server_classes
+            .get(<ClassId as Into<usize>>::into(packet.server_class))
+            .map(|s| s.name.to_string())
+            .unwrap_or("UNKNOWN_PROJECTILE".to_string());
+
+        let mut p = ProjectilePatch::default();
+        Projectile::parse(packet, parser_state, game, &mut p);
+
+        let origin = p.origin.unwrap_or_else(|| {
+            if class_name != "CTFProjectile_EnergyRing" {
+                error!("No origin for Projectile! {:?} {packet:?}", class_name);
+            }
+            Vec3::default()
+        });
+
+        let is_sentry = if class_name == "CTFProjectile_SentryRocket" {
+            game.world.intersections_with_point(
+                game.rigid_body_set,
+                game.collider_set,
+                &origin,
+                QueryFilter::new().predicate(&|_handle, c| {
+                    if let Some(e) = &game.entities[c.user_data as usize] {
+                        e.class() == EntityClass::Sentry
+                    } else {
+                        error!("Could not find entity from user_data: {}", c.user_data);
+                        false
+                    }
+                }),
+                |coll| {
+                    // unwrap() safety: this is a lookup into the very set we are iterating over.
+                    let collider = game.collider_set.get(coll).unwrap();
+
+                    let eid = collider.user_data as usize;
+                    let Some(entity) = &game.entities[eid] else {
+                        error!(
+                            "Collided with a broken entity id when checking sentry rocket {eid}"
+                        );
+                        return false;
+                    };
+
+                    p.owner = entity.owner();
+
+                    false // Only ever look at the first match.
+                },
+            );
+            true
+        } else {
+            false
+        };
+
+        let owner = p
+            .owner
+            .and_then(|x| if x == INVALID_HANDLE { None } else { Some(x) })
+            .or(p
+                .original_launcher_handle
+                .and_then(|h| game.weapon_owners.get(&h))
+                .and_then(|uid| game.player_summaries.get(uid))
+                .and_then(|p| game.get_player(&p.entity_id))
+                .and_then(|p| p.handle()))
+            .unwrap_or_else(|| {
+                error!("No owner for Projectile! {packet:?}");
+                0
+            });
+
+        let mut original_owner = owner;
+
+        let launcher = p
+            .original_launcher_handle
+            .and_then(|h| game.entity_handles.get(&h))
+            .and_then(|eid| {
+                game.entities
+                    .get(usize::from(*eid))
+                    .and_then(|b| b.as_ref())
+            })
+            .and_then(|e| e.weapon());
+
+        if let Some(launcher) = launcher {
+            if owner != launcher.owner {
+                if p.is_reflected == Some(true) {
+                    original_owner = launcher.owner;
+                } else {
+                    error!(
+                        "original owner on non-reflected projectile does not match launcher owner"
+                    );
+                }
+            }
+        } else if !is_sentry {
+            error!("No launcher found for projectile");
+        }
+
+        let launcher_schema = launcher.map(|w| w.schema_id);
+        let item = launcher_schema.and_then(|id| game.schema.items.get(&id));
+        let mut kind = match class_name.as_str() {
+            "CTFProjectile_EnergyRing" => ProjectileType::EnergyRing,
+            "CTFProjectile_HealingBolt" => ProjectileType::HealingBolt,
+            "CTFProjectile_Rocket" => ProjectileType::Rocket,
+            "CTFProjectile_SentryRocket" => ProjectileType::SentryRocket,
+            "CTFProjectile_JarMilk" => ProjectileType::MadMilk,
+            "CTFProjectile_BallOfFire" => ProjectileType::DragonsFuryFire,
+            "CTFProjectile_Cleaver" => ProjectileType::Cleaver,
+            "CTFBall_Ornament" => ProjectileType::WrapAssassin,
+            "CTFProjectile_EnergyBall" => ProjectileType::CowMangler,
+            "CTFStunBall" => ProjectileType::Sandman,
+            "CTFProjectile_MechanicalArmOrb" => ProjectileType::ShortCircuit,
+            _ => ProjectileType::Unknown,
+        };
+
+        if let Some(s) = item {
+            if let Some(l) = &s.item_class {
+                if l == "tf_weapon_shotgun_building_rescue" {
+                    kind = ProjectileType::RescueRanger;
+                } else if l == "tf_weapon_compound_bow" {
+                    kind = ProjectileType::HuntsmanArrow;
+                } else if l == "tf_weapon_jar" {
+                    kind = ProjectileType::Jarate;
+                } else if l == "tf_weapon_jar_gas" {
+                    kind = ProjectileType::GasPasser;
+                }
+            }
+
+            if let Some(l) = &s.item_name {
+                if l == "#TF_Weapon_Sticky_Quickie" {
+                    kind = ProjectileType::QuickieBomb;
+                } else if l == "#TF_Unique_Achievement_StickyLauncher" {
+                    kind = ProjectileType::ScottishResistance;
+                } else if l == "#TF_Weapon_StickyBomb_Jump" {
+                    kind = ProjectileType::StickyBombJumper;
+                } else if l == "#TF_Weapon_Iron_bomber" {
+                    kind = ProjectileType::IronBomber;
+                } else if l == "#TF_LochNLoad" {
+                    kind = ProjectileType::LochNLoad;
+                } else if l == "#TF_Weapon_Cannon" {
+                    kind = ProjectileType::LooseCannon;
+                } else if l == "#TF_Weapon_PipebombLauncher"
+                    || l.starts_with("#TF_Weapon_StickybombLauncher_")
+                {
+                    kind = ProjectileType::StickyBomb;
+                } else if l.starts_with("#TF_Weapon_GrenadeLauncher") {
+                    kind = ProjectileType::Pipe;
+                }
+            }
+
+            let mode = s.attributes.iter().find_map(|(_k, v)| {
+                if let Attribute::String(StringAttribute {
+                    attribute_class,
+                    value,
+                }) = &v
+                {
+                    if attribute_class == "set_weapon_mode" {
+                        return Some(value.as_str());
+                    }
+                }
+                None
+            });
+
+            if class_name == "CTFProjectile_Flare" {
+                kind = match mode {
+                    Some("1") => ProjectileType::DetonatorFlare,
+                    Some("2") => ProjectileType::ManmelterFlare,
+                    Some("3") => ProjectileType::ScorchShotFlare,
+                    _ => ProjectileType::Flare,
+                }
+            }
+        }
+
+        if matches!(kind, ProjectileType::Unknown) {
+            error!("Unknown launcher type for {class_name} {item:?}");
+        }
+
+        if launcher_schema.is_none() && !is_sentry {
+            error!("No projectile launcher class {class_name} {p:?}");
+        }
+
+        Self {
+            launcher_schema_id: launcher_schema,
+            is_sentry,
+            original_launcher_handle: 0, // only for reading owner
+            origin,
+            velocity: Default::default(),
+            original_owner,
+            owner,
+            is_reflected: p.is_reflected.unwrap_or(false),
+            original_team: p.team.unwrap_or(Team::Spectator),
+            team: p.team.unwrap_or(Team::Spectator),
+            class_name,
+            grenade_type: p.grenade_type,
+            model_id: p.model_id,
+            effects: p.effects.unwrap_or_default(),
+            kind,
+        }
+    }
+
+    fn parse_preserve(
+        &self,
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> Box<dyn Any> {
+        let mut patch = Box::new(ProjectilePatch::default());
+        Projectile::parse(packet, parser_state, game, &mut patch);
+
+        let owner_changed = patch.owner.map(|r| r != self.owner).unwrap_or(false);
+        let team_changed = patch.team.map(|r| r != self.team).unwrap_or(false);
+        if team_changed && !owner_changed {
+            error!("Projectile changed team without changing owner entity {patch:?}");
+        }
+
+        let disappeared = if let Some(new_effects) = patch.effects {
+            new_effects.contains(Effects::NoDraw) && !self.effects.contains(Effects::NoDraw)
+        } else {
+            false
+        };
+
+        if can_hurt_without_exploding(self.kind)
+            || (disappeared && self.kind == ProjectileType::ScottishResistance)
+        {
+            game.explosions.push(Explosion {
+                origin: self.origin,
+                projectile: Box::new(self.clone()),
+            });
+        }
+
+        patch
+    }
+
+    fn delete(self: Box<Self>, game: &mut MatchAnalyzerView) {
+        game.explosions.push(Explosion {
+            origin: self.origin,
+            projectile: self,
+        });
+    }
+
+    fn apply_preserve(&mut self, patch: Box<dyn Any>) {
+        let patch = patch.downcast::<ProjectilePatch>().unwrap();
+
+        if let (p, Some(n)) = (self.origin, patch.origin) {
+            self.velocity = (n - p).into();
+        }
+
+        self.merge_opt(*patch);
+    }
+
+    fn shape(&self) -> Option<SharedShape> {
+        Some(PROJECTILE_BOX.clone())
+    }
+
+    fn origin(&self) -> Option<Vec3> {
+        Some(self.origin)
+    }
+
+    fn owner(&self) -> Option<u32> {
+        Some(self.owner)
+    }
+
+    fn class(&self) -> EntityClass {
+        EntityClass::Projectile
+    }
+
+    fn projectile(&self) -> Option<&Projectile> {
+        Some(self)
+    }
+}

--- a/src/parser/entity/sentry.rs
+++ b/src/parser/entity/sentry.rs
@@ -1,0 +1,123 @@
+use crate::{
+    convert_vec,
+    parser::{
+        entity::{Entity, EntityClass, SENTRY_BOX},
+        props::*,
+        summarizer::MatchAnalyzerView,
+    },
+    Vec3,
+};
+use parry3d::shape::SharedShape;
+use std::any::Any;
+use tf_demo_parser::{
+    demo::{
+        message::packetentities::{EntityId, PacketEntity},
+        sendprop::SendPropValue,
+    },
+    ParserState,
+};
+use tracing::error;
+
+#[optfield::optfield(SentryPatch, merge_fn, attrs)]
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Sentry {
+    pub origin: Vec3,
+    pub owner: u32, // handle id
+    pub owner_entity: EntityId,
+    pub level: u32,
+    pub is_mini: bool,
+}
+
+impl Sentry {
+    fn parse(
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> SentryPatch {
+        let mut patch = SentryPatch::default();
+
+        for prop in packet.props(parser_state) {
+            match (prop.identifier, &prop.value) {
+                (ORIGIN, &SendPropValue::Vector(o)) => patch.origin = Some(convert_vec(o)),
+                (BUILDER, &SendPropValue::Integer(b)) => {
+                    let h = b as u32;
+                    patch.owner = Some(h);
+                    if let Some(eid) = game.entity_handles.get(&h) {
+                        patch.owner_entity = Some(*eid);
+                    }
+                }
+                (UPGRADE_LEVEL, &SendPropValue::Integer(l)) => patch.level = Some(l as u32),
+                (OBJECT_MAX_HEALTH, &SendPropValue::Integer(l)) => {
+                    patch.is_mini = Some(l == 100);
+                }
+                _ => {}
+            }
+        }
+        patch
+    }
+}
+
+impl Entity for Sentry {
+    fn new(
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> Self {
+        let patch = Sentry::parse(packet, parser_state, game);
+
+        Self {
+            origin: patch.origin.unwrap_or_else(|| {
+                error!("No origin for Sentry gun! {packet:?}");
+                Vec3::default()
+            }),
+            owner: patch.owner.unwrap_or_else(|| {
+                error!("No owner for Sentry gun! {packet:?}");
+                0
+            }),
+            owner_entity: patch.owner_entity.unwrap_or_else(|| {
+                error!("No owner entity for Sentry gun! {packet:?}");
+                EntityId::default()
+            }),
+            level: patch.level.unwrap_or_else(|| {
+                error!("No level for Sentry gun! {packet:?}");
+                0
+            }),
+            is_mini: patch.is_mini.unwrap_or_else(|| {
+                error!("No is_mini based on max hp for Sentry gun! {packet:?}");
+                false
+            }),
+        }
+    }
+
+    fn parse_preserve(
+        &self,
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> Box<dyn Any> {
+        Box::new(Sentry::parse(packet, parser_state, game))
+    }
+
+    fn apply_preserve(&mut self, patch: Box<dyn Any>) {
+        let patch = patch.downcast::<SentryPatch>().unwrap();
+        self.merge_opt(*patch);
+    }
+
+    fn shape(&self) -> Option<SharedShape> {
+        Some(SENTRY_BOX.clone())
+    }
+    fn origin(&self) -> Option<Vec3> {
+        Some(self.origin)
+    }
+
+    fn owner(&self) -> Option<u32> {
+        Some(self.owner)
+    }
+
+    fn class(&self) -> EntityClass {
+        EntityClass::Sentry
+    }
+    fn sentry(&self) -> Option<&Sentry> {
+        Some(self)
+    }
+}

--- a/src/parser/entity/shield.rs
+++ b/src/parser/entity/shield.rs
@@ -1,0 +1,96 @@
+use crate::parser::{
+    entity::{Entity, EntityClass},
+    props::*,
+    summarizer::MatchAnalyzerView,
+};
+use std::any::Any;
+use tf_demo_parser::{
+    demo::{
+        message::packetentities::PacketEntity, packet::datatable::ClassId, sendprop::SendPropValue,
+    },
+    ParserState,
+};
+
+#[optfield::optfield(ShieldPatch, merge_fn, attrs)]
+#[derive(Debug, PartialEq, Default)]
+pub struct Shield {
+    pub class_name: String,
+    pub owner: u32,
+    pub handle: u32,
+    pub schema_id: u32,
+}
+
+impl Shield {
+    fn parse(packet: &PacketEntity, parser_state: &ParserState, patch: &mut ShieldPatch) {
+        for prop in packet.props(parser_state) {
+            match (prop.identifier, &prop.value) {
+                (SELF_HANDLE, &SendPropValue::Integer(h)) => {
+                    patch.handle = Some(h as u32);
+                }
+                (OWNER, &SendPropValue::Integer(h)) => {
+                    patch.owner = Some(h as u32);
+                }
+                (ITEM_DEFINITION, &SendPropValue::Integer(id)) => {
+                    patch.schema_id = Some(id as u32);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Entity for Shield {
+    fn new(
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        _game: &mut MatchAnalyzerView,
+    ) -> Self {
+        let class_name = parser_state
+            .server_classes
+            .get(<ClassId as Into<usize>>::into(packet.server_class))
+            .map(|s| s.name.to_string())
+            .unwrap_or("UNKNOWN_PROJECTILE".to_string());
+
+        let mut p = ShieldPatch::default();
+        Shield::parse(packet, parser_state, &mut p);
+
+        let mut s = Self {
+            class_name,
+            ..Default::default()
+        };
+        s.merge_opt(p);
+        s
+    }
+
+    fn parse_preserve(
+        &self,
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        _game: &mut MatchAnalyzerView,
+    ) -> Box<dyn Any> {
+        let mut p = Box::new(ShieldPatch::default());
+        Shield::parse(packet, parser_state, &mut p);
+        p
+    }
+
+    fn apply_preserve(&mut self, patch: Box<dyn Any>) {
+        let patch = patch.downcast::<ShieldPatch>().unwrap();
+        self.merge_opt(*patch);
+    }
+
+    fn owner(&self) -> Option<u32> {
+        Some(self.owner)
+    }
+
+    fn handle(&self) -> Option<u32> {
+        Some(self.handle)
+    }
+
+    fn class(&self) -> EntityClass {
+        EntityClass::Shield
+    }
+
+    fn shield(&self) -> Option<&Shield> {
+        Some(self)
+    }
+}

--- a/src/parser/entity/weapon.rs
+++ b/src/parser/entity/weapon.rs
@@ -1,0 +1,138 @@
+use crate::parser::{
+    entity::{Entity, EntityClass},
+    props::*,
+    summarizer::{Event, MatchAnalyzerView},
+};
+use std::any::Any;
+use tf_demo_parser::{
+    demo::{
+        message::packetentities::PacketEntity, packet::datatable::ClassId, sendprop::SendPropValue,
+    },
+    ParserState,
+};
+use tracing::trace;
+
+#[optfield::optfield(WeaponPatch, merge_fn, attrs)]
+#[derive(Debug, PartialEq, Default)]
+pub struct Weapon {
+    pub class_name: String,
+
+    // medigunn
+    pub last_high_charge: f32,
+    pub charge: f32,
+    pub charge_released: bool,
+
+    pub handle: u32,
+    pub owner: u32,
+
+    pub schema_id: u32,
+    pub model_id: u32,
+
+    pub reset_parity: u32,
+}
+
+impl Weapon {
+    fn parse(packet: &PacketEntity, parser_state: &ParserState, patch: &mut WeaponPatch) {
+        let class_name = parser_state
+            .server_classes
+            .get(<ClassId as Into<usize>>::into(packet.server_class))
+            .map(|s| s.name.to_string())
+            .unwrap_or("UNKNOWN_PROJECTILE".to_string());
+        for prop in packet.props(parser_state) {
+            match (prop.identifier, &prop.value) {
+                (MEDIGUN_CHARGE_LEVEL, &SendPropValue::Float(z)) => {
+                    patch.charge = Some(z);
+                }
+                (MEDIGUN_CHARGE_RELEASED, &SendPropValue::Integer(b)) => {
+                    patch.charge_released = Some(b == 1)
+                }
+                (SELF_HANDLE, &SendPropValue::Integer(h)) => patch.handle = Some(h as u32),
+                (ITEM_DEFINITION, &SendPropValue::Integer(x)) => patch.schema_id = Some(x as u32),
+                (MODEL, &SendPropValue::Integer(x)) => patch.model_id = Some(x as u32),
+                (WEAPON_OWNER, &SendPropValue::Integer(x)) => patch.owner = Some(x as u32),
+                (RESET_PARITY, &SendPropValue::Integer(x)) => patch.reset_parity = Some(x as u32),
+
+                _ => {
+                    trace!(
+                        "Unknown weaapon prop on {} {class_name}: {prop:?}",
+                        packet.entity_index
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl Entity for Weapon {
+    fn new(
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        _game: &mut MatchAnalyzerView,
+    ) -> Self {
+        let class_name = parser_state
+            .server_classes
+            .get(<ClassId as Into<usize>>::into(packet.server_class))
+            .map(|s| s.name.to_string())
+            .unwrap_or("UNKNOWN_PROJECTILE".to_string());
+
+        let mut p = WeaponPatch::default();
+        Weapon::parse(packet, parser_state, &mut p);
+
+        let mut s = Self {
+            class_name,
+            ..Default::default()
+        };
+        s.merge_opt(p);
+        s
+    }
+
+    fn parse_preserve(
+        &self,
+        packet: &PacketEntity,
+        parser_state: &ParserState,
+        game: &mut MatchAnalyzerView,
+    ) -> Box<dyn Any> {
+        let mut p = WeaponPatch::default();
+        Weapon::parse(packet, parser_state, &mut p);
+
+        if let Some(released) = p.charge_released {
+            if released && self.charge_released != released {
+                game.tick_events.push(Event::MedigunCharged(self.handle));
+            }
+        }
+
+        Box::new(p)
+    }
+
+    fn apply_preserve(&mut self, patch: Box<dyn Any>) {
+        let patch = patch.downcast::<WeaponPatch>().unwrap();
+
+        // Hack: mediguns get set to 0 charge the same tick that the med dies, but we want to keep
+        // the value around a bit longer. So just delay resetting the medigun until the next update.
+        if let Some(charge) = patch.charge {
+            if charge > 0.0 {
+                self.last_high_charge = charge;
+            }
+        } else if patch.reset_parity.is_some() {
+            self.last_high_charge = 0.0;
+        }
+
+        self.merge_opt(*patch);
+    }
+
+    fn owner(&self) -> Option<u32> {
+        Some(self.owner)
+    }
+
+    fn handle(&self) -> Option<u32> {
+        Some(self.handle)
+    }
+
+    fn class(&self) -> EntityClass {
+        EntityClass::Weapon
+    }
+
+    fn weapon(&self) -> Option<&Weapon> {
+        Some(self)
+    }
+}

--- a/src/parser/game.rs
+++ b/src/parser/game.rs
@@ -1,4 +1,4 @@
-use enumset::EnumSetType;
+use enumset::{EnumSet, EnumSetType};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 
@@ -22,8 +22,18 @@ pub enum RoundState {
 }
 
 pub const INVALID_HANDLE: u32 = 0x1fffff;
-pub const ENTITY_ON_GROUND: u16 = 1;
-pub const ENTITY_IN_WATER: u16 = 1 << 9;
+
+#[derive(
+    Copy, Clone, Deserialize, Serialize, IntoPrimitive, TryFromPrimitive, PartialEq, Debug, Default,
+)]
+#[repr(u16)]
+pub enum GrenadeType {
+    #[default]
+    Pipe = 0, // Stock and Iron Bomber -- distinguish those by model id if necessary
+    Sticky = 1,
+    StickyJumper = 2,
+    Cannonball = 3,
+}
 
 #[derive(
     Copy, Clone, Deserialize, Serialize, IntoPrimitive, TryFromPrimitive, PartialEq, Debug,
@@ -114,160 +124,210 @@ pub enum DamageType {
     Croc = 81,
     TauntGasBlast = 82,
     AxtinguisherBoosted = 83,
+    KrampusMelee = 84,
+    KrampusRanged = 85,
+}
+
+#[derive(
+    Copy, Clone, Deserialize, Serialize, IntoPrimitive, TryFromPrimitive, PartialEq, Debug,
+)]
+#[repr(u8)]
+pub enum DamageEffect {
+    Normal = 4,
+    Crit = 0,
+    MiniCrit = 1,
+    DoubleDonk = 2,
+    WaterSplash = 3,
+    DragonsFuryBonus = 5,
+    Stomp = 6,
 }
 
 #[derive(Deserialize, Serialize, IntoPrimitive, TryFromPrimitive, PartialEq, Debug)]
 #[repr(u16)]
 pub enum WeaponId {
-    WeaponNone = 0,
-    WeaponBat = 1,
-    WeaponBatWood = 2,
-    WeaponBottle = 3,
-    WeaponFireaxe = 4,
-    WeaponClub = 5,
-    WeaponCrowbar = 6,
-    WeaponKnife = 7,
-    WeaponFists = 8,
-    WeaponShovel = 9,
-    WeaponWrench = 10,
-    WeaponBonesaw = 11,
-    WeaponShotgunPrimary = 12,
-    WeaponShotgunSoldier = 13,
-    WeaponShotgunHwg = 14,
-    WeaponShotgunPyro = 15,
-    WeaponScattergun = 16,
-    WeaponSniperrifle = 17,
-    WeaponMinigun = 18,
-    WeaponSmg = 19,
-    WeaponSyringegunMedic = 20,
-    WeaponTranq = 21,
-    WeaponRocketlauncher = 22,
-    WeaponGrenadelauncher = 23,
-    WeaponPipebomblauncher = 24,
-    WeaponFlamethrower = 25,
-    WeaponGrenadeNormal = 26,
-    WeaponGrenadeConcussion = 27,
-    WeaponGrenadeNail = 28,
-    WeaponGrenadeMirv = 29,
-    WeaponGrenadeMirvDemoman = 30,
-    WeaponGrenadeNapalm = 31,
-    WeaponGrenadeGas = 32,
-    WeaponGrenadeEmp = 33,
-    WeaponGrenadeCaltrop = 34,
-    WeaponGrenadePipebomb = 35,
-    WeaponGrenadeSmokeBomb = 36,
-    WeaponGrenadeHeal = 37,
-    WeaponGrenadeStunball = 38,
-    WeaponGrenadeJar = 39,
-    WeaponGrenadeJarMilk = 40,
-    WeaponPistol = 41,
-    WeaponPistolScout = 42,
-    WeaponRevolver = 43,
-    WeaponNailgun = 44,
-    WeaponPda = 45,
-    WeaponPdaEngineerBuild = 46,
-    WeaponPdaEngineerDestroy = 47,
-    WeaponPdaSpy = 48,
-    WeaponBuilder = 49,
-    WeaponMedigun = 50,
-    WeaponGrenadeMirvbomb = 51,
-    WeaponFlamethrowerRocket = 52,
-    WeaponGrenadeDemoman = 53,
-    WeaponSentryBullet = 54,
-    WeaponSentryRocket = 55,
-    WeaponDispenser = 56,
-    WeaponInvis = 57,
-    WeaponFlaregun = 58,
-    WeaponLunchbox = 59,
-    WeaponJar = 60,
-    WeaponCompoundBow = 61,
-    WeaponBuffItem = 62,
-    WeaponPumpkinBomb = 63,
-    WeaponSword = 64,
-    WeaponRocketlauncherDirecthit = 65,
-    WeaponLifeline = 66,
-    WeaponLaserPointer = 67,
-    WeaponDispenserGun = 68,
-    WeaponSentryRevenge = 69,
-    WeaponJarMilk = 70,
-    WeaponHandgunScoutPrimary = 71,
-    WeaponBatFish = 72,
-    WeaponCrossbow = 73,
-    WeaponStickbomb = 74,
-    WeaponHandgunScoutSecondary = 75,
-    WeaponSodaPopper = 76,
-    WeaponSniperrifleDecap = 77,
-    WeaponRaygun = 78,
-    WeaponParticleCannon = 79,
-    WeaponMechanicalArm = 80,
-    WeaponDrgPomson = 81,
-    WeaponBatGiftwrap = 82,
-    WeaponGrenadeOrnamentBall = 83,
-    WeaponFlaregunRevenge = 84,
-    WeaponPepBrawlerBlaster = 85,
-    WeaponCleaver = 86,
-    WeaponGrenadeCleaver = 87,
-    WeaponStickyBallLauncher = 88,
-    WeaponGrenadeStickyBall = 89,
-    WeaponShotgunBuildingRescue = 90,
-    WeaponCannon = 91,
-    WeaponThrowable = 92,
-    WeaponGrenadeThrowable = 93,
-    WeaponPdaSpyBuild = 94,
-    WeaponGrenadeWaterballoon = 95,
-    WeaponHarvesterSaw = 96,
-    WeaponSpellbook = 97,
-    WeaponSpellbookProjectile = 98,
-    WeaponSniperrifleClassic = 99,
-    WeaponParachute = 100,
-    WeaponGrapplinghook = 101,
-    WeaponPasstimeGun = 102,
-    WeaponSniperrifleRevolver = 103,
-    WeaponChargedSmg = 104,
+    None = 0,
+    Bat = 1,
+    BatWood = 2,
+    Bottle = 3,
+    Fireaxe = 4,
+    Club = 5,
+    Crowbar = 6,
+    Knife = 7,
+    Fists = 8,
+    Shovel = 9,
+    Wrench = 10,
+    Bonesaw = 11,
+    ShotgunPrimary = 12,
+    ShotgunSoldier = 13,
+    ShotgunHwg = 14,
+    ShotgunPyro = 15,
+    Scattergun = 16,
+    Sniperrifle = 17,
+    Minigun = 18,
+    Smg = 19,
+    SyringegunMedic = 20,
+    Tranq = 21,
+    Rocketlauncher = 22,
+    Grenadelauncher = 23,
+    Pipebomblauncher = 24,
+    Flamethrower = 25,
+    GrenadeNormal = 26,
+    GrenadeConcussion = 27,
+    GrenadeNail = 28,
+    GrenadeMirv = 29,
+    GrenadeMirvDemoman = 30,
+    GrenadeNapalm = 31,
+    GrenadeGas = 32,
+    GrenadeEmp = 33,
+    GrenadeCaltrop = 34,
+    GrenadePipebomb = 35,
+    GrenadeSmokeBomb = 36,
+    GrenadeHeal = 37,
+    GrenadeStunball = 38,
+    GrenadeJar = 39,
+    GrenadeJarMilk = 40,
+    Pistol = 41,
+    PistolScout = 42,
+    Revolver = 43,
+    Nailgun = 44,
+    Pda = 45,
+    PdaEngineerBuild = 46,
+    PdaEngineerDestroy = 47,
+    PdaSpy = 48,
+    Builder = 49,
+    Medigun = 50,
+    GrenadeMirvbomb = 51,
+    FlamethrowerRocket = 52,
+    GrenadeDemoman = 53,
+    SentryBullet = 54,
+    SentryRocket = 55,
+    Dispenser = 56,
+    Invis = 57,
+    Flaregun = 58,
+    Lunchbox = 59,
+    Jar = 60,
+    CompoundBow = 61,
+    BuffItem = 62,
+    PumpkinBomb = 63,
+    Sword = 64,
+    RocketlauncherDirecthit = 65,
+    Lifeline = 66,
+    LaserPointer = 67,
+    DispenserGun = 68,
+    SentryRevenge = 69,
+    JarMilk = 70,
+    HandgunScoutPrimary = 71,
+    BatFish = 72,
+    Crossbow = 73,
+    Stickbomb = 74,
+    HandgunScoutSecondary = 75,
+    SodaPopper = 76,
+    SniperrifleDecap = 77,
+    Raygun = 78,
+    ParticleCannon = 79,
+    MechanicalArm = 80,
+    DrgPomson = 81,
+    BatGiftwrap = 82,
+    GrenadeOrnamentBall = 83,
+    FlaregunRevenge = 84,
+    PepBrawlerBlaster = 85,
+    Cleaver = 86,
+    GrenadeCleaver = 87,
+    StickyBallLauncher = 88,
+    GrenadeStickyBall = 89,
+    ShotgunBuildingRescue = 90,
+    Cannon = 91,
+    Throwable = 92,
+    GrenadeThrowable = 93,
+    PdaSpyBuild = 94,
+    GrenadeWaterballoon = 95,
+    HarvesterSaw = 96,
+    Spellbook = 97,
+    SpellbookProjectile = 98,
+    SniperrifleClassic = 99,
+    Parachute = 100,
+    Grapplinghook = 101,
+    PasstimeGun = 102,
+    SniperrifleRevolver = 103,
+    ChargedSmg = 104,
+    BreakableSign = 105,
+    Rocketpack = 106,
+    Slap = 107,
+    JarGas = 108,
+    GrenadeJarGas = 109,
+    FlameBall = 110,
 }
 
-#[repr(u8)]
+impl WeaponId {
+    pub fn is_melee(&self) -> bool {
+        matches!(
+            self,
+            WeaponId::Bat
+                | WeaponId::BatWood
+                | WeaponId::Bottle
+                | WeaponId::Fireaxe
+                | WeaponId::Club
+                | WeaponId::Crowbar
+                | WeaponId::Knife
+                | WeaponId::Fists
+                | WeaponId::Shovel
+                | WeaponId::Wrench
+                | WeaponId::Bonesaw
+                | WeaponId::Sword
+                | WeaponId::BatFish
+                | WeaponId::MechanicalArm
+                | WeaponId::BatGiftwrap
+                | WeaponId::Cleaver
+                | WeaponId::HarvesterSaw
+                | WeaponId::Slap
+        )
+    }
+}
+
+#[repr(u32)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TryFromPrimitive)]
-pub enum PlayerAnim {
-    AttackPrimary,
-    AttackSecondary,
-    AttackGrenade,
-    Reload,
-    ReloadLoop,
-    ReloadEnd,
-    Jump,
-    Swim,
-    Die,
-    FlinchChest,
-    FlinchHead,
-    FlinchLeftarm,
-    FlinchRightarm,
-    FlinchLeftleg,
-    FlinchRightleg,
-    Doublejump,
-    Cancel,
-    Spawn,
-    SnapYaw,
-    Custom, // Used to play specific activities
-    CustomGesture,
-    CustomSequence, // Used to play specific sequences
-    CustomGestureSequence,
-    AttackPre,
-    AttackPost,
-    Grenade1Draw,
-    Grenade2Draw,
-    Grenade1Throw,
-    Grenade2Throw,
-    VoiceCommandGesture,
-    DoublejumpCrouch,
-    StunBegin,
-    StunMiddle,
-    StunEnd,
-    PasstimeThrowBegin,
-    PasstimeThrowMiddle,
-    PasstimeThrowEnd,
-    PasstimeThrowCancel,
-    AttackPrimarySuper,
+pub enum PlayerAnimation {
+    AttackPrimary = 0,
+    AttackSecondary = 1,
+    AttackGrenade = 2,
+    Reload = 3,
+    ReloadLoop = 4,
+    ReloadEnd = 5,
+    Jump = 6,
+    Swim = 7,
+    Die = 8,
+    FlinchChest = 9,
+    FlinchHead = 10,
+    FlinchLeftarm = 11,
+    FlinchRightarm = 12,
+    FlinchLeftleg = 13,
+    FlinchRightleg = 14,
+    Doublejump = 15,
+    Cancel = 16,
+    Spawn = 17,
+    SnapYaw = 18,
+    Custom = 19, // Used to play specific activities
+    CustomGesture = 20,
+    CustomSequence = 21, // Used to play specific sequences
+    CustomGestureSequence = 22,
+    AttackPre = 23,
+    AttackPost = 24,
+    Grenade1Draw = 25,
+    Grenade2Draw = 26,
+    Grenade1Throw = 27,
+    Grenade2Throw = 28,
+    VoiceCommandGesture = 29,
+    DoublejumpCrouch = 30,
+    StunBegin = 31,
+    StunMiddle = 32,
+    StunEnd = 33,
+    PasstimeThrowBegin = 34,
+    PasstimeThrowMiddle = 35,
+    PasstimeThrowEnd = 36,
+    ContractPdaBegin = 37,
+    ContractPdaMiddle = 38,
+    ContractPdaEnd = 39,
+    AttackPrimarySuper = 40,
 }
 
 #[repr(u16)]
@@ -425,4 +485,98 @@ pub enum PlayerCondition {
     // PowerupModeDominant = 129,
     // ImmuneToPushback = 130,
 }
-//pub const LAST_CONDITION: PlayerCondition = PlayerCondition::GrappledByPlayer;
+
+pub fn update_condition<const OFFSET: usize>(condition: &mut EnumSet<PlayerCondition>, bits: u32) {
+    let mask: u128 = 0xffffffff << OFFSET;
+    let new_cond = (condition.as_repr() & !mask) | ((bits as u128) << OFFSET);
+    *condition = EnumSet::<PlayerCondition>::from_repr(new_cond);
+}
+
+#[repr(u32)]
+#[derive(Debug, Serialize, Deserialize, TryFromPrimitive, EnumSetType)]
+#[enumset(repr = "u32")]
+pub enum Damage {
+    Crush = 0,
+    Bullet = 1,
+    Slash = 2,
+    Burn = 3,
+    Vehicle = 4,
+    Fall = 5,
+    Blast = 6,
+    Club = 7,
+    Shock = 8,
+    Sonic = 9,
+    NoFalloff = 10,
+    PreventPhysicsForce = 11,
+    NeverGib = 12,
+    AlwaysGib = 13,
+    Drown = 14,
+    Paralyze = 15,
+    NerveGas = 16,
+    NoFalloffTooClose = 17,
+    HalfFalloff = 18,
+    DrownRecover = 19,
+    Crit = 20,
+    DoFalloff = 21,
+    RemoveNoRagdoll = 22,
+    PhysGun = 23,
+    Ignite = 24,
+    HitLocation = 25, // Sniper, ambassador
+    DontCountTowardsCritRate = 26,
+    Melee = 27,
+    Direct = 28,
+    Buckshot = 29,
+}
+
+#[repr(u32)]
+#[derive(Debug, Serialize, Deserialize, TryFromPrimitive, EnumSetType)]
+#[enumset(repr = "u32")]
+pub enum Flags {
+    OnGround = 0,
+    Ducking = 1,
+    WaterJump = 2,
+    OnTrain = 3,
+    InRain = 4,
+    Frozen = 5,
+    AtControls = 6,
+    Client = 7,
+    FakeClient = 8,
+    InWater = 9,
+    Fly = 10,
+    Swim = 11,
+    Conveyor = 12,
+    Npc = 13,
+    GodMode = 14,
+    Notarget = 15,
+    AimTarget = 16,
+    PartialGround = 17,
+    StaticProp = 18,
+    Graphed = 19,
+    Grenade = 20,
+    StepMovement = 21,
+    DontTouch = 22,
+    BaseVelocity = 23,
+    WorldBrush = 24,
+    Object = 25,
+    KillMe = 26,
+    OnFire = 27,
+    Dissolving = 28,
+    TransRagdoll = 29,
+    UnblockableByPlayer = 30,
+}
+
+#[repr(u16)]
+#[derive(Debug, Serialize, Deserialize, TryFromPrimitive, EnumSetType)]
+#[enumset(repr = "u16")]
+pub enum Effects {
+    BoneMerge = 0,
+    BrightLight = 1,
+    DimLight = 2,
+    NoInterp = 3,
+    NoShadow = 4,
+    NoDraw = 5,
+    NoReceiveShadow = 6,
+    BoneMergeFastCull = 7,
+    ItemBlink = 8,
+    ParentAnimates = 9,
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,7 @@
+mod entity;
 mod game;
+mod props;
+mod stats;
 pub mod summarizer;
 mod weapon;
 
@@ -30,4 +33,13 @@ pub fn parse(buffer: &[u8], schema: &Schema) -> tf_demo_parser::Result<DemoOutpu
         summary,
         filename: None,
     })
+}
+
+// Helpers for serde serialization
+pub fn is_zero(num: &u32) -> bool {
+    *num == 0
+}
+
+pub fn is_false(b: &bool) -> bool {
+    !(*b)
 }

--- a/src/parser/props.rs
+++ b/src/parser/props.rs
@@ -1,0 +1,140 @@
+use tf_demo_parser::demo::sendprop::SendPropIdentifier;
+
+pub const MEDIGUN_CHARGE_LEVEL: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFWeaponMedigunDataNonLocal", "m_flChargeLevel");
+pub const MEDIGUN_CHARGE_RELEASED: SendPropIdentifier =
+    SendPropIdentifier::new("DT_WeaponMedigun", "m_bChargeRelease");
+pub const SELF_HANDLE: SendPropIdentifier =
+    SendPropIdentifier::new("DT_AttributeContainer", "m_hOuter");
+pub const ITEM_DEFINITION: SendPropIdentifier =
+    SendPropIdentifier::new("DT_ScriptCreatedItem", "m_iItemDefinitionIndex");
+
+pub const MODEL: SendPropIdentifier = SendPropIdentifier::new("DT_BaseEntity", "m_nModelIndex");
+pub const TEAM: SendPropIdentifier = SendPropIdentifier::new("DT_BaseEntity", "m_iTeamNum");
+pub const SIM_TIME: SendPropIdentifier =
+    SendPropIdentifier::new("DT_BaseEntity", "m_flSimulationTime");
+pub const ORIGIN: SendPropIdentifier = SendPropIdentifier::new("DT_BaseEntity", "m_vecOrigin");
+pub const OWNER: SendPropIdentifier = SendPropIdentifier::new("DT_BaseEntity", "m_hOwnerEntity");
+pub const EFFECTS: SendPropIdentifier = SendPropIdentifier::new("DT_BaseEntity", "m_fEffects");
+
+pub const BUILDER: SendPropIdentifier = SendPropIdentifier::new("DT_BaseObject", "m_hBuilder");
+pub const UPGRADE_LEVEL: SendPropIdentifier =
+    SendPropIdentifier::new("DT_BaseObject", "m_iUpgradeLevel");
+
+// This is the max upgrade the sentry ever reached (ie if it goes down via red tape
+// recorder). *Not* the max possible level.
+pub const _MAX_UPGRADE_LEVEL: SendPropIdentifier =
+    SendPropIdentifier::new("DT_BaseObject", "m_iHighestUpgradeLevel");
+
+pub const OBJECT_MAX_HEALTH: SendPropIdentifier =
+    SendPropIdentifier::new("DT_BaseObject", "m_iMaxHealth");
+
+pub const ORIGIN_XY: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFNonLocalPlayerExclusive", "m_vecOrigin");
+pub const ORIGIN_Z: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFNonLocalPlayerExclusive", "m_vecOrigin[2]");
+
+pub const FLAGS: SendPropIdentifier = SendPropIdentifier::new("DT_BasePlayer", "m_fFlags");
+pub const HEALTH: SendPropIdentifier = SendPropIdentifier::new("DT_BasePlayer", "m_iHealth");
+pub const CLASS: SendPropIdentifier = SendPropIdentifier::new("DT_TFPlayerClassShared", "m_iClass");
+
+pub const EYE_X: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFNonLocalPlayerExclusive", "m_angEyeAngles[0]");
+pub const EYE_Y: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFNonLocalPlayerExclusive", "m_angEyeAngles[1]");
+
+pub const HANDLE: SendPropIdentifier = SendPropIdentifier::new("DT_AttributeManager", "m_hOuter");
+
+pub const COND_0: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerShared", "m_nPlayerCond");
+pub const COND_1: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerShared", "m_nPlayerCondEx");
+pub const COND_2: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerShared", "m_nPlayerCondEx2");
+pub const COND_3: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerShared", "m_nPlayerCondEx3");
+
+// Separate condition bits
+// TODO: seems to only be used for Kritzkreig?
+pub const COND_BITS: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerConditionListExclusive", "_condition_bits");
+
+pub const COND_SOURCE: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerConditionSource", "m_pProvider");
+
+pub const ACTIVE_WEAPON_HANDLE: SendPropIdentifier =
+    SendPropIdentifier::new("DT_BaseCombatCharacter", "m_hActiveWeapon");
+
+// These DT_TFPlayerScoringDataExclusive props are only present in PoV demos, not STV demos.
+//
+// Other fields: m_iDominations, m_iRevenge,
+// m_iBuildingsDestroyed, m_iHeadshots, m_iBackstabs,
+// m_iHealPoints, m_iInvulns, m_iTeleports, m_iDamageDone,
+// m_iBonusPoints, m_iPoints, m_iCaptures, m_iDefenses
+pub const KILLS: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerScoringDataExclusive", "m_iKills");
+pub const DEATHS: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerScoringDataExclusive", "m_iDeaths");
+pub const KILL_ASSISTS: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFPlayerScoringDataExclusive", "m_iKillAssists");
+
+pub const WEP_0: SendPropIdentifier = SendPropIdentifier::new("m_hMyWeapons", "000");
+pub const WEP_1: SendPropIdentifier = SendPropIdentifier::new("m_hMyWeapons", "001");
+pub const WEP_2: SendPropIdentifier = SendPropIdentifier::new("m_hMyWeapons", "002");
+pub const WEP_3: SendPropIdentifier = SendPropIdentifier::new("m_hMyWeapons", "003");
+pub const WEP_4: SendPropIdentifier = SendPropIdentifier::new("m_hMyWeapons", "004");
+pub const WEP_5: SendPropIdentifier = SendPropIdentifier::new("m_hMyWeapons", "005");
+pub const WEP_6: SendPropIdentifier = SendPropIdentifier::new("m_hMyWeapons", "006");
+
+pub const NUM_COSMETICS: SendPropIdentifier =
+    SendPropIdentifier::new("_LPT_m_hMyWearables_8", "lengthprop8");
+
+pub const COSMETIC_0: SendPropIdentifier = SendPropIdentifier::new("_ST_m_hMyWearables_8", "000");
+pub const COSMETIC_1: SendPropIdentifier = SendPropIdentifier::new("_ST_m_hMyWearables_8", "001");
+pub const COSMETIC_2: SendPropIdentifier = SendPropIdentifier::new("_ST_m_hMyWearables_8", "002");
+pub const COSMETIC_3: SendPropIdentifier = SendPropIdentifier::new("_ST_m_hMyWearables_8", "003");
+pub const COSMETIC_4: SendPropIdentifier = SendPropIdentifier::new("_ST_m_hMyWearables_8", "004");
+pub const COSMETIC_5: SendPropIdentifier = SendPropIdentifier::new("_ST_m_hMyWearables_8", "005");
+pub const COSMETIC_6: SendPropIdentifier = SendPropIdentifier::new("_ST_m_hMyWearables_8", "006");
+pub const COSMETIC_7: SendPropIdentifier = SendPropIdentifier::new("_ST_m_hMyWearables_8", "007");
+
+pub const RESET_PARITY: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFWeaponBase", "m_bResetParity");
+
+// DT_TFBaseRocket is for most rockets, arrows, and maybe more?
+pub const ROCKET_ORIGIN: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFBaseRocket", "m_vecOrigin");
+pub const ROCKET_DEFLECTED: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFBaseRocket", "m_iDeflected");
+
+pub const GRENADE_ORIGIN: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFWeaponBaseGrenadeProj", "m_vecOrigin");
+pub const GRENADE_DEFLECTED: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFWeaponBaseGrenadeProj", "m_iDeflected");
+
+pub const WEAPON_OWNER: SendPropIdentifier =
+    SendPropIdentifier::new("DT_BaseCombatWeapon", "m_hOwner");
+
+pub const INITIAL_SPEED: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFBaseRocket", "m_vInitialVelocity");
+pub const ORIGINAL_LAUNCHER: SendPropIdentifier =
+    SendPropIdentifier::new("DT_BaseProjectile", "m_hOriginalLauncher");
+pub const PIPE_TYPE: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFProjectile_Pipebomb", "m_iType");
+pub const ROCKET_ROTATION: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFBaseRocket", "m_angRotation");
+pub const GRENADE_ROTATION: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFWeaponBaseGrenadeProj", "m_angRotation");
+pub const DEFLECT_OWNER: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TFWeaponBaseGrenadeProj", "m_hDeflectOwner");
+
+pub const WAITING_FOR_PLAYERS: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TeamplayRoundBasedRules", "m_bInWaitingForPlayers");
+pub const ROUND_STATE: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TeamplayRoundBasedRules", "m_iRoundState");
+
+// Temp entities
+pub const EFFECT_ENTITY: SendPropIdentifier = SendPropIdentifier::new("DT_EffectData", "entindex");
+pub const ANIM_PLAYER: SendPropIdentifier =
+    SendPropIdentifier::new("DT_TEPlayerAnimEvent", "m_hPlayer");
+pub const ANIM_ID: SendPropIdentifier = SendPropIdentifier::new("DT_TEPlayerAnimEvent", "m_iEvent");

--- a/src/parser/stats.rs
+++ b/src/parser/stats.rs
@@ -1,0 +1,184 @@
+use crate::parser::{
+    game::{DamageType, Death, RoundState},
+    is_zero,
+};
+use enumset::EnumSet;
+use serde::{Deserialize, Serialize};
+use tf_demo_parser::demo::gameevent_gen::PlayerHurtEvent;
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct Stats {
+    #[serde(skip_serializing_if = "is_zero")]
+    pub kills: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub assists: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub deaths: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub postround_kills: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub postround_assists: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub postround_deaths: u32,
+
+    // Dupes with HealersSummary to cover non-med healing
+    #[serde(skip_serializing_if = "is_zero")]
+    pub preround_healing: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub healing: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub postround_healing: u32,
+
+    #[serde(skip_serializing_if = "is_zero")]
+    pub damage: u32, // Added up PlayerHurt events
+    #[serde(skip_serializing_if = "is_zero")]
+    pub damage_taken: u32,
+
+    #[serde(skip_serializing_if = "is_zero")]
+    pub dominations: u32, // This player dominated another player
+    #[serde(skip_serializing_if = "is_zero")]
+    pub dominated: u32, // Another player dominated this player
+    #[serde(skip_serializing_if = "is_zero")]
+    pub revenges: u32, // This player got revenge on another player
+    #[serde(skip_serializing_if = "is_zero")]
+    pub revenged: u32, // Another player got revenge on this player
+
+    // Kills where the victim was in the air for a decent amount of time.
+    // TOOD: clarify this definition
+    #[serde(skip_serializing_if = "is_zero")]
+    pub airshots: u32,
+
+    #[serde(skip_serializing_if = "is_zero")]
+    pub headshot_kills: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub backstab_kills: u32,
+
+    #[serde(skip_serializing_if = "is_zero")]
+    pub headshots: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub backstabs: u32,
+
+    #[serde(skip_serializing_if = "is_zero")]
+    pub was_headshot: u32,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub was_backstabbed: u32,
+    // TODO
+    // pub shots: u32,
+    // pub hits: u32,
+}
+
+impl Stats {
+    pub fn handle_damage_dealt(&mut self, hurt: &PlayerHurtEvent, damage_type: DamageType) {
+        self.damage += hurt.damage_amount as u32;
+
+        if damage_type == DamageType::Backstab {
+            self.backstabs += 1;
+        } else if damage_type == DamageType::Headshot {
+            self.headshots += 1;
+        }
+    }
+
+    pub fn handle_damage_taken(&mut self, hurt: &PlayerHurtEvent, damage_type: DamageType) {
+        self.damage_taken += hurt.damage_amount as u32;
+
+        if damage_type == DamageType::Backstab {
+            self.was_backstabbed += 1;
+        } else if damage_type == DamageType::Headshot {
+            self.was_headshot += 1;
+        }
+    }
+
+    pub fn handle_death(&mut self, round_state: RoundState, flags: EnumSet<Death>) {
+        if flags.contains(Death::Domination) {
+            self.dominated += 1;
+        }
+        if flags.contains(Death::AssisterDomination) {
+            self.dominated += 1;
+        }
+        if flags.contains(Death::Revenge) {
+            self.revenged += 1;
+        }
+        if flags.contains(Death::AssisterRevenge) {
+            self.revenged += 1;
+        }
+
+        if flags.contains(Death::Feign) {
+            return;
+        }
+
+        if round_state == RoundState::TeamWin {
+            self.postround_deaths += 1;
+        } else {
+            self.deaths += 1;
+        }
+    }
+
+    pub fn handle_assist(&mut self, round_state: RoundState, flags: EnumSet<Death>) {
+        if flags.contains(Death::AssisterDomination) {
+            self.dominations += 1;
+        }
+        if flags.contains(Death::AssisterRevenge) {
+            self.revenges += 1;
+        }
+
+        if flags.contains(Death::Feign) {
+            return;
+        }
+
+        if round_state == RoundState::TeamWin {
+            self.postround_assists += 1;
+        } else {
+            self.assists += 1;
+        }
+    }
+
+    pub fn handle_kill(
+        &mut self,
+        round_state: RoundState,
+        flags: EnumSet<Death>,
+        damage_type: DamageType,
+        airshot: bool,
+    ) {
+        if flags.contains(Death::Domination) {
+            self.dominations += 1;
+        }
+        if flags.contains(Death::Revenge) {
+            self.revenges += 1;
+        }
+
+        if flags.contains(Death::Feign) {
+            return;
+        }
+
+        if round_state == RoundState::TeamWin {
+            self.postround_kills += 1;
+            return;
+        }
+
+        self.kills += 1;
+
+        if airshot {
+            self.airshots += 1;
+        }
+
+        if damage_type == DamageType::Backstab {
+            self.backstab_kills += 1;
+        } else if damage_type == DamageType::Headshot {
+            self.headshot_kills += 1;
+        }
+    }
+
+    pub fn handle_healing(&mut self, round_state: RoundState, amount: u32) {
+        if round_state == RoundState::TeamWin {
+            return;
+        }
+
+        if round_state == RoundState::PreRound {
+            self.preround_healing += amount;
+        } else if round_state == RoundState::TeamWin {
+            self.postround_healing += amount;
+        } else {
+            self.healing += amount;
+        }
+    }
+}

--- a/src/parser/weapon.rs
+++ b/src/parser/weapon.rs
@@ -1,4 +1,13 @@
+use crate::{
+    parser::{
+        entity::{self, ProjectileType},
+        game::{DamageType, GrenadeType},
+    },
+    schema,
+};
 use serde::{Deserialize, Serialize};
+use tf_demo_parser::demo::parser::analyser::{Class, Team};
+use tracing::{error, trace};
 
 #[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd, Default)]
 pub enum Weapon {
@@ -16,4 +25,213 @@ pub enum Weapon {
     ShotgunEngy,
     ShitgunHWG,
     ShotgunPyro,
+}
+
+pub fn strip_prefix(killer_weapon_name: &str) -> &str {
+    let prefixes = ["tf_weapon_grenade_", "tf_weapon_", "NPC_", "func_"];
+
+    for prefix in prefixes {
+        if let Some(weapon) = killer_weapon_name.strip_prefix(prefix) {
+            return weapon;
+        }
+    }
+
+    killer_weapon_name
+}
+
+pub fn sentry_name(sentry: &entity::Sentry) -> &'static str {
+    if sentry.is_mini {
+        return "obj_minisentry";
+    }
+    match sentry.level {
+        1 => "obj_sentrygun",
+        2 => "obj_sentrygun2",
+        3 => "obj_sentrygun3",
+        _ => {
+            error!("Unexpected sentry gun type {sentry:?}");
+            "obj_sentrygun"
+        }
+    }
+}
+
+pub fn log_name(weapon_name: &str, class: Class) -> &str {
+    match weapon_name {
+        "rocketlauncher" => "tf_projectile_rocket",
+        "grenadelauncher" => "tf_projectile_pipe",
+        "pipebomblauncher" => "tf_projectile_pipe_remote",
+        "compound_bow" => "tf_projectile_arrow",
+        "pistol" => match class {
+            Class::Scout => "pistol_scout",
+            _ => "pistol",
+        },
+        "shotgun" => match class {
+            Class::Scout => "scattergun",
+            Class::Soldier => "shotgun_soldier",
+            Class::Heavy => "shotgun_hwg",
+            Class::Pyro => "shotgun_pyro",
+            Class::Engineer => "shotgun_primary",
+            _ => {
+                error!("Shotgun on unexpected class! {class:?}");
+                "shotgun"
+            }
+        },
+        _ => weapon_name,
+    }
+
+    //   weapon_name
+}
+
+pub fn projectile_log_name(
+    p: &entity::Projectile,
+    target_team: &Team,
+    item: Option<&schema::Item>,
+) -> &'static str {
+    if p.is_sentry {
+        return if p.is_reflected {
+            "deflect_rocket"
+        } else {
+            "obj_sentrygun3"
+        };
+    }
+    trace!("proj log name target:{:?} {p:?}", target_team);
+    if p.is_reflected
+        && (p.original_team == *target_team
+            || (p.original_team != *target_team
+                && p.owner != p.original_owner
+								// reflected sticky kills on their own team get attributed to the original
+								// demo who triggers the det.
+                && !entity::is_sticky(p.kind)))
+    {
+        if entity::is_arrow(p.kind) {
+            return "deflect_arrow";
+        }
+        if p.kind == ProjectileType::CowMangler {
+            return "deflect_rocket";
+        }
+        if p.kind == ProjectileType::ShortCircuit {
+            // TF2 Doesn't emit this! TF2 seems to just emit "tf_projectile_energy_ball" but it's
+            // better to distinguish this case.
+            return "deflect_tf_projectile_energy_ball";
+        }
+        if p.kind == ProjectileType::DetonatorFlare {
+            // TF2 Doesn't emit this! TF2 seems to just emit "tf_projectile_energy_ball" but it's
+            // better to distinguish this case.
+            return "deflect_flare_detonator";
+        }
+        if let Some(t) = p.grenade_type {
+            return match t {
+                GrenadeType::Pipe => "deflect_promode",
+                GrenadeType::Sticky => "deflect_sticky",
+                GrenadeType::StickyJumper => {
+                    error!("Reflect kill with a sticky jumper?!");
+                    "deflect_sticky"
+                }
+                GrenadeType::Cannonball => "loose_cannon_reflect",
+            };
+        }
+        return match p.class_name.as_ref() {
+            "CTFProjectile_Rocket" => "deflect_rocket",
+            "CTFProjectile_Flare" => "deflect_flare",
+            _ => {
+                error!(
+                    "Unknown reflected projectile class: {} {:?}",
+                    p.class_name, p.kind
+                );
+                "deflect_UNKNOWN"
+            }
+        };
+    }
+    let class_name = p.class_name.as_str();
+    if class_name == "CTFProjectile_MechanicalArmOrb" {
+        return "tf_projectile_mechanicalarmorb";
+    }
+    if let Some(ref item) = item {
+        trace!("projectile has schema {item:?}");
+        if let Some(ref ln) = item.item_logname {
+            return ustr::ustr(ln).as_str();
+        }
+        if let Some(ref class) = item.item_class {
+            if class == "tf_weapon_rocketlauncher_directhit" {
+                return "rocketlauncher_directhit";
+            }
+        }
+    }
+    if let Some(t) = p.grenade_type {
+        return match t {
+            GrenadeType::Pipe => "tf_projectile_pipe",
+            GrenadeType::Sticky => "tf_projectile_pipe_remote",
+            GrenadeType::StickyJumper => {
+                error!("Kill with a sticky jumper?!");
+                "tf_projectile_pipe_remote"
+            }
+            GrenadeType::Cannonball => "loose_cannon",
+        };
+    }
+    match p.kind {
+        ProjectileType::HealingBolt => return "crusaders_crossbow",
+        ProjectileType::HuntsmanArrow => return "tf_projectile_arrow",
+        ProjectileType::ScorchShotFlare => return "scorch_shot",
+        _ => {}
+    }
+    match class_name {
+        "CTFProjectile_Rocket" => "tf_projectile_rocket",
+        "CTFProjectile_Flare" => "flaregun",
+        _ => {
+            error!("Unhandled projectile type: {}", p.class_name);
+            "UNKNWON"
+        }
+    }
+}
+
+pub fn taunt_log_name(damage_type: DamageType) -> Option<&'static str> {
+    match damage_type {
+        DamageType::TauntHadouken => Some("taunt_pyro"),
+        DamageType::TauntHighNoon => Some("taunt_heavy"),
+        DamageType::TauntGrandSlam => Some("taunt_scout"),
+        DamageType::TauntFencing => Some("taunt_spy"),
+        DamageType::TauntArrowStab => Some("taunt_sniper"),
+        DamageType::TauntGrenade => {
+            // this could be taunt_soldier_lumbricus if the
+            // worms grenade is equipped....
+            Some("taunt_soldier")
+        }
+        DamageType::TauntBarbarianSwing => Some("taunt_demoman"),
+        DamageType::TauntUberslice => Some("taunt_medic"),
+        DamageType::TauntEngineerGuitarSmash => Some("taunt_guitar_kill"),
+        DamageType::TauntEngineerArmKill => Some("robot_arm_blender_kill"),
+        DamageType::TauntArmageddon => Some("armageddon"),
+        DamageType::TauntAllclassGuitarRiff => Some("taunt_guitar_riff_kill"),
+        DamageType::TauntGasBlast => Some("gas_blast"),
+        _ => None,
+    }
+}
+
+pub fn projectile_explosion_radius(projectile_class_name: &str) -> f32 {
+    match projectile_class_name {
+        "CTFProjectile_SentryRocket" | "CTFProjectile_Rocket" | "CTFProjectile_EnergyBall" => 146.0,
+        // airstrike is 0.90 -- but maybe we just store the mult_explosion_radius ?
+        // lochnload is 0.75
+        // grenadelauncher is 0.85
+        // directhit is 0.3
+        // beggars is 0.8
+        "CTFGrenadePipebombProjectile" => 146.0 * 0.85,
+
+        // flares are really complicated!!! lots of variations and rules
+        "CTFProjectile_Flare" => 110.0,
+        "CTFBall_Ornament" => 50.0,
+
+        "CTFProjectile_JarMilk" => 200.0,
+
+        "CTFStunBall" | "CTFProjectile_Cleaver" => 0.1, // its an OnHit check in game
+
+        "CTFProjectile_EnergyRing" | "CTFProjectile_Arrow" | "CTFProjectile_HealingBolt" => 2.0, // traces a line, no explosion
+
+        _ => {
+            error!(
+                "Unknown projectile needs explosion radius: {}",
+                projectile_class_name
+            );
+            146.0
+        }
+    }
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -293,7 +293,7 @@ struct ApiResponse<T> {
 
 async fn fetch_bytes() -> Result<String> {
     let schema_path_var = std::env::var("TF2_SCHEMA_PATH").or(env::var("DEMO_TF2_SCHEMA_PATH"));
-    if let Some(schema_string) = schema_path_var.ok() {
+    if let Ok(schema_string) = schema_path_var {
         let schema_path = std::path::Path::new(&schema_string);
         return Ok(std::fs::read_to_string(schema_path)
             .map_err(|e| format!("Error {e}: While reading {schema_path:?}"))?);


### PR DESCRIPTION
Based on top of #12

This is almost a full rewrite of the actual demo analysis logic. Sorry for not splitting into smaller PRs -- this was a very dynamic prototyping process.

Turns out, the "weapon id" metadata in most game events, including PlayerHurt events, is very poor for non-hitscan weapons. All projectiles (including rockets and demo explosives which are a _majority_ of all damage) along with pyro burning and sentry shots would be very inaccurate if we relied on the metadata available in the game events.  

So I pulled in a collision detection library ([rapier3d](https://docs.rs/rapier3d/latest/rapier3d/) and [surrounding ecosystem](https://dimforge.com/)), track the positions and hitboxes of all players and projectiles, and calculate the hits.

The code is still quite hacky and messy.... But I at least got it to cleanly pass clippy. 

It is ~99% accurate (estimated using death events as ground truth -- they have more metadata we can validate against) and mostly only misses rare edge cases like:
  - player died while being shot by engi pistol and that engi's sentry in the same tick and there's no way to determine if it was a pistol or sentry kill
  - player took damage from a demo's pipe and sticky in the same tick
  - player took recurring burn damage in the same tick they got hit by new pyro fire source
  - machina penetration shots (we just always log as "machina" instead of separately flagging some hits as "player_penetration" which will probably be simpler for downstream stats anyways). 
  - sometimes demo recording starts a bit late and so some id numbers are missing/incorrect. This is usually all preround gameplay so no big deal we just log a few errors but process the rest of the demo as normal. 

There's probably also a few other rare logic issue; but across 1,000 demo files we're never wrong in the same way more than ~10 times.

Performance is still pretty good, most demos are fully processed in under a second.