### PR TITLE
Move player summaries to be per-round 

### DIFF
--- a/src/parser/entity/projectile.rs
+++ b/src/parser/entity/projectile.rs
@@ -143,7 +143,8 @@ impl Projectile {
                         let handle = game
                             .weapon_owners
                             .get(&launcher)
-                            .and_then(|uid| game.player_summaries.get(uid))
+                            .and_then(|uid| game.user_id_to_steam_id.get(uid))
+                            .and_then(|sid| game.player_summaries.get(sid))
                             .and_then(|p| game.get_player(&p.entity_id))
                             .and_then(|p| p.handle());
 
@@ -283,7 +284,8 @@ impl Entity for Projectile {
             .or(p
                 .original_launcher_handle
                 .and_then(|h| game.weapon_owners.get(&h))
-                .and_then(|uid| game.player_summaries.get(uid))
+                .and_then(|uid| game.user_id_to_steam_id.get(uid))
+                .and_then(|sid| game.player_summaries.get(sid))
                 .and_then(|p| game.get_player(&p.entity_id))
                 .and_then(|p| p.handle()))
             .unwrap_or_else(|| {

--- a/src/parser/player.rs
+++ b/src/parser/player.rs
@@ -16,7 +16,7 @@ use tf_demo_parser::demo::{
 };
 use tracing::error;
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct PlayerSummary {
     pub name: String,
     pub steamid: String,
@@ -258,5 +258,20 @@ impl PlayerSummary {
             2.0 => self.handle_charge_quickfix(),
             x => error!("Unknown medigun charge type: {}", x),
         }
+    }
+
+    pub fn reset_stats(&mut self) {
+        self.stats = Stats::default();
+        self.classes.clear();
+        self.weapons.clear();
+        // scoreboard_healing is temporary and reset implicitly or explicitly elsewhere.
+        // postround_kills, assists, deaths are reset by virtue of Stats::default()
+        self.suicides = 0; // Reset suicides per round
+        self.captures = 0;
+        self.captures_blocked = 0;
+        // charge and kritzed are transient states, not long-term stats to be reset here.
+        // points, bonus_points, scoreboard_kills, scoreboard_assists, scoreboard_deaths, scoreboard_damage
+        // are generally cumulative or snapshot from game messages, not reset here unless explicitly required
+        // to be per-round from source. For now, assuming they reflect overall demo state or are updated by game.
     }
 }

--- a/src/parser/stats.rs
+++ b/src/parser/stats.rs
@@ -6,7 +6,7 @@ use enumset::EnumSet;
 use serde::{Deserialize, Serialize};
 use tf_demo_parser::demo::gameevent_gen::PlayerHurtEvent;
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Stats {
     #[serde(skip_serializing_if = "is_zero")]
     pub kills: u32,


### PR DESCRIPTION
Based on #21

Fixes #18 

Removes top level `players` property and instead adds a `players` property to each round, showing the player's stats from that round. 